### PR TITLE
Updating AckSystemMessage

### DIFF
--- a/src/main/java/com/prowidesoftware/swift/model/SwiftMessage.java
+++ b/src/main/java/com/prowidesoftware/swift/model/SwiftMessage.java
@@ -1512,7 +1512,7 @@ public class SwiftMessage implements Serializable, JsonSerializable {
 	 * <p>If you have a MT102 in a SwiftMessage, this method is the same as invoking
 	 * <code>new MT102(SwiftMessage)</code>.
 	 * <p>For messages with service id 21 = GPA/FIN Message (ACK/NAK/UAK/UNK) it will
-	 * return an instance of {@link AckSystemMessage}.
+	 * return an instance of {@link SystemMessage}.
 	 * 
 	 * @return created specific MT object or null if the message type is not set or an error occurs during message creation 
 	 */
@@ -1520,7 +1520,7 @@ public class SwiftMessage implements Serializable, JsonSerializable {
 		final String type = getType();
 		if (type == null) {
 			if (isServiceMessage21()) {
-				return AckSystemMessage.newInstance(this);
+				return SystemMessage.newInstance(this);
 			}
 			log.warning("Cannot determine the message type from application header (block 2)");
 		} else {

--- a/src/main/java/com/prowidesoftware/swift/model/mt/SystemMessage.java
+++ b/src/main/java/com/prowidesoftware/swift/model/mt/SystemMessage.java
@@ -34,13 +34,13 @@ import com.prowidesoftware.swift.utils.Lib;
  * 
  * @since 7.8
  */
-public class AckSystemMessage extends AbstractMT {
+public class SystemMessage extends AbstractMT {
 
 	/**
 	 * @param aMessage
 	 * @throws RuntimeException if the message is not a service message with service id 21 (meaning positive or negative acknowledge)
 	 */
-	public AckSystemMessage(final SwiftMessage aMessage) {
+	public SystemMessage(final SwiftMessage aMessage) {
 		super(aMessage);
 		Validate.isTrue(aMessage.isServiceMessage21());
 	}
@@ -50,26 +50,26 @@ public class AckSystemMessage extends AbstractMT {
 	 * @throws RuntimeException if the message is not a service message with service id 21 (meaning positive or negative acknowledge)
 	 */
 	public static AbstractMT newInstance(final SwiftMessage swiftMessage) {
-		return new AckSystemMessage(swiftMessage);
+		return new SystemMessage(swiftMessage);
 	}
 	
 	/**
-	 * Creates an AckSystemMessage initialized with the parameter MtSwiftMessage.
+	 * Creates an SystemMessage initialized with the parameter MtSwiftMessage.
 	 *
-	 * @param m swift message with the AckSystemMessage content
+	 * @param m swift message with the SystemMessage content
 	 * @return the created object or null if the parameter is null
-	 * @see #AckSystemMessage(String)
+	 * @see #SystemMessage(String)
 	 * @since 7.8.9
 	 */
-	public static AckSystemMessage parse(MtSwiftMessage m) {
+	public static SystemMessage parse(MtSwiftMessage m) {
 		if (m == null) {
 			return null;
 		}
-		return new AckSystemMessage(m.message());
+		return new SystemMessage(m.message());
 	}
 	
     /**
-	 * Creates a new AckSystemMessage by parsing a input stream with the message content in its swift FIN format, using "UTF-8" as encoding.<br>
+	 * Creates a new SystemMessage by parsing a input stream with the message content in its swift FIN format, using "UTF-8" as encoding.<br>
 	 * If the message content is null or cannot be parsed, the internal message object
 	 * will be initialized (blocks will be created) but empty.<br>
 	 * If the stream contains multiple messages, only the first one will be parsed.
@@ -77,27 +77,27 @@ public class AckSystemMessage extends AbstractMT {
 	 * @param stream an input stream in UTF-8 encoding with the MT message in its FIN swift format.
 	 * @since 7.8.9
 	 */
-	public AckSystemMessage(final InputStream stream) throws IOException {
+	public SystemMessage(final InputStream stream) throws IOException {
 		this(Lib.readStream(stream));
     }
     
     /**
-	 * Creates a new AckSystemMessage by parsing a input stream with the message content in its swift FIN format, using "UTF-8" as encoding.<br>
+	 * Creates a new SystemMessage by parsing a input stream with the message content in its swift FIN format, using "UTF-8" as encoding.<br>
 	 * If the stream contains multiple messages, only the first one will be parsed.
 	 *
 	 * @param stream an input stream in UTF-8 encoding with the MT message in its FIN swift format.
-	 * @return a new instance of AckSystemMessage or null if stream is null or the message cannot be parsed 
+	 * @return a new instance of SystemMessage or null if stream is null or the message cannot be parsed
 	 * @since 7.8.9
 	 */
-	public static AckSystemMessage parse(final InputStream stream) throws IOException {
+	public static SystemMessage parse(final InputStream stream) throws IOException {
 		if (stream == null) {
 			return null;
 		}
-		return new AckSystemMessage(stream);
+		return new SystemMessage(stream);
     }
     
     /**
-	 * Creates a new AckSystemMessage by parsing a file with the message content in its swift FIN format.<br>
+	 * Creates a new SystemMessage by parsing a file with the message content in its swift FIN format.<br>
 	 * If the file content is null or cannot be parsed as a message, the internal message object
 	 * will be initialized (blocks will be created) but empty.<br>
 	 * If the file contains multiple messages, only the first one will be parsed.
@@ -105,27 +105,27 @@ public class AckSystemMessage extends AbstractMT {
 	 * @param file a file with the MT message in its FIN swift format.
 	 * @since 7.8.9
 	 */
-	public AckSystemMessage(final File file) throws IOException {
+	public SystemMessage(final File file) throws IOException {
 		this(Lib.readFile(file));
     }
     
     /**
-	 * Creates a new AckSystemMessage by parsing a file with the message content in its swift FIN format.<br>
+	 * Creates a new SystemMessage by parsing a file with the message content in its swift FIN format.<br>
 	 * If the file contains multiple messages, only the first one will be parsed.
 	 *
 	 * @param file a file with the MT message in its FIN swift format.
-	 * @return a new instance of AckSystemMessage or null if; file is null, does not exist, can't be read, is not a file or the message cannot be parsed
+	 * @return a new instance of SystemMessage or null if; file is null, does not exist, can't be read, is not a file or the message cannot be parsed
 	 * @since 7.8.9
 	 */
-	public static AckSystemMessage parse(final File file) throws IOException {
+	public static SystemMessage parse(final File file) throws IOException {
 		if (file == null) {
 			return null;
 		}
-		return new AckSystemMessage(file);
+		return new SystemMessage(file);
     }
     
 	/**
-	 * Creates a new AckSystemMessage by parsing a String with the message content in its swift FIN format.<br>
+	 * Creates a new SystemMessage by parsing a String with the message content in its swift FIN format.<br>
 	 * If the fin parameter is null or the message cannot be parsed, the internal message object
 	 * will be initialized (blocks will be created) but empty.<br>
 	 * If the string contains multiple messages, only the first one will be parsed.
@@ -134,7 +134,7 @@ public class AckSystemMessage extends AbstractMT {
  	 * @throws RuntimeException if the message is not a service message with service id 21 (meaning positive or negative acknowledge)
 	 * @since 7.8.9
 	 */
-	public AckSystemMessage(final String fin) {
+	public SystemMessage(final String fin) {
 		super();
 		if (fin != null) {
 			final SwiftMessage parsed = read(fin);
@@ -146,19 +146,19 @@ public class AckSystemMessage extends AbstractMT {
     }
 
 	/**
-	 * Creates a new AckSystemMessage by parsing a String with the message content in its swift FIN format.<br>
+	 * Creates a new SystemMessage by parsing a String with the message content in its swift FIN format.<br>
 	 * If the file contains multiple messages, only the first one will be parsed.
 	 *
 	 * @param fin a string with the MT message in its FIN swift format
-	 * @return a new instance of AckSystemMessage or null if; fin is null or the message cannot be parsed
+	 * @return a new instance of SystemMessage or null if; fin is null or the message cannot be parsed
  	 * @throws RuntimeException if the message is not a service message with service id 21 (meaning positive or negative acknowledge)
 	 * @since 7.8.9
 	 */
-	public static AckSystemMessage parse(final String fin) {
+	public static SystemMessage parse(final String fin) {
 		if (fin == null) {
 			return null;
 		}
-		return new AckSystemMessage(fin);
+		return new SystemMessage(fin);
 	}
 	
 	/**

--- a/src/test/java/com/prowidesoftware/swift/model/mt/SystemMessageTest.java
+++ b/src/test/java/com/prowidesoftware/swift/model/mt/SystemMessageTest.java
@@ -19,25 +19,25 @@ package com.prowidesoftware.swift.model.mt;
 import org.junit.Ignore;
 
 @Ignore
-public class AckSystemMessageTest {
+public class SystemMessageTest {
 
 	/* sebastian marxo 2016 los getters con Fieldnn se sacaron por dependencia circular en codegen
 	@Test
 	public void testParseAck() {
-		AckSystemMessage ack = AckSystemMessage.parse("{1:F21MLCOUS33AXXX0221000001}{4:{177:1702040914}{451:0}}");
-		assertNotNull(ack);
-		assertTrue(ack.isAck());
-		assertEquals("1702040914", ack.getField177().getValue());
-		assertEquals("0", ack.getField451().getValue());
+		SystemMessage sysMessage = SystemMessage.parse("{1:F21MLCOUS33AXXX0221000001}{4:{177:1702040914}{451:0}}");
+		assertNotNull(sysMessage);
+		assertTrue(sysMessage.isAck());
+		assertEquals("1702040914", sysMessage.getField177().getValue());
+		assertEquals("0", sysMessage.getField451().getValue());
 	}
-	
+
 	@Test
 	public void testParseNak() {
-		AckSystemMessage ack = AckSystemMessage.parse("{1:F21MLCOUS33AXXX0221000001}{4:{177:1702040914}{451:1}}");
-		assertNotNull(ack);
-		assertTrue(ack.isNack());
-		assertEquals("1702040914", ack.getField177().getValue());
-		assertEquals("1", ack.getField451().getValue());
+		SystemMessage sysMessage = SystemMessage.parse("{1:F21MLCOUS33AXXX0221000001}{4:{177:1702040914}{451:1}}");
+		assertNotNull(sysMessage);
+		assertTrue(sysMessage.isNack());
+		assertEquals("1702040914", sysMessage.getField177().getValue());
+		assertEquals("1", sysMessage.getField451().getValue());
 	}
 	*/
 }


### PR DESCRIPTION
Because 'AckSystemMessage' is a "Generic MT representation for service messages with service id 21 = GPA/FIN Message (ACK/NAK/UAK/UNK). It can hold both a positive or negative acknowledge. " it seems appropriate to have a more generic name of 'SystemMessage' (perhaps 'ServiceMessage' may be more so?).

It could be misleading to be working with a nak of type AckSystemMessage, particularly when performing calls such as .isNack(). SystemMessageTest (formerly AckSystemMessageTest ) has a concrete example of how a name change may be of benefit. 