### PR TITLE
Migration to Jakarta EE 10

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -54,11 +54,11 @@ dependencies {
     implementation 'org.apache.commons:commons-lang3:3.12.0'
     implementation 'com.google.code.gson:gson:2.9.0'
 
-    compileOnly 'javax.persistence:javax.persistence-api:2.2'
-    compileOnly 'javax.xml.bind:jaxb-api:2.3.1'
-    compileOnly 'javax.validation:validation-api:2.0.1.Final'
+    compileOnly 'jakarta.persistence:jakarta.persistence-api:3.1.0'
+    compileOnly 'jakarta.xml.bind:jakarta.xml.bind-api:4.0.0'
+    compileOnly 'jakarta.validation:jakarta.validation-api:3.0.2'
 
-    testImplementation 'javax.persistence:javax.persistence-api:2.2'
+    testImplementation 'jakarta.persistence:jakarta.persistence-api:3.1.0'
     testImplementation('org.junit.jupiter:junit-jupiter:5.8.2')
     testImplementation group: 'org.assertj', name: 'assertj-core', version: '3.22.0'
     testImplementation group: 'org.xmlunit', name: 'xmlunit-core', version: '2.9.0'

--- a/src/main/java/com/prowidesoftware/swift/constraints/BicConstraint.java
+++ b/src/main/java/com/prowidesoftware/swift/constraints/BicConstraint.java
@@ -17,13 +17,13 @@ package com.prowidesoftware.swift.constraints;
 
 import static java.lang.annotation.ElementType.*;
 
+import jakarta.validation.Constraint;
+import jakarta.validation.Payload;
+
 import java.lang.annotation.Documented;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
-
-import javax.validation.Constraint;
-import javax.validation.Payload;
 
 /**
  * Bean validation for BIC numbers.

--- a/src/main/java/com/prowidesoftware/swift/constraints/BicValidator.java
+++ b/src/main/java/com/prowidesoftware/swift/constraints/BicValidator.java
@@ -17,10 +17,9 @@ package com.prowidesoftware.swift.constraints;
 
 import com.prowidesoftware.swift.model.BIC;
 import com.prowidesoftware.swift.model.BicValidationResult;
+import jakarta.validation.ConstraintValidator;
+import jakarta.validation.ConstraintValidatorContext;
 import org.apache.commons.lang3.StringUtils;
-
-import javax.validation.ConstraintValidator;
-import javax.validation.ConstraintValidatorContext;
 
 /**
  * Implementation of the BIC validation constraint

--- a/src/main/java/com/prowidesoftware/swift/constraints/CountryConstraint.java
+++ b/src/main/java/com/prowidesoftware/swift/constraints/CountryConstraint.java
@@ -17,13 +17,13 @@ package com.prowidesoftware.swift.constraints;
 
 import static java.lang.annotation.ElementType.*;
 
+import jakarta.validation.Constraint;
+import jakarta.validation.Payload;
+
 import java.lang.annotation.Documented;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
-
-import javax.validation.Constraint;
-import javax.validation.Payload;
 
 /**
  * Bean validation for ISO Alpha-2 country codes.

--- a/src/main/java/com/prowidesoftware/swift/constraints/CountryValidator.java
+++ b/src/main/java/com/prowidesoftware/swift/constraints/CountryValidator.java
@@ -16,10 +16,9 @@
 package com.prowidesoftware.swift.constraints;
 
 import com.prowidesoftware.swift.utils.IsoUtils;
+import jakarta.validation.ConstraintValidator;
+import jakarta.validation.ConstraintValidatorContext;
 import org.apache.commons.lang3.StringUtils;
-
-import javax.validation.ConstraintValidator;
-import javax.validation.ConstraintValidatorContext;
 
 /**
  * Implementation of the ISO Alpha-2 country validation constraint

--- a/src/main/java/com/prowidesoftware/swift/constraints/CurrencyConstraint.java
+++ b/src/main/java/com/prowidesoftware/swift/constraints/CurrencyConstraint.java
@@ -17,13 +17,13 @@ package com.prowidesoftware.swift.constraints;
 
 import static java.lang.annotation.ElementType.*;
 
+import jakarta.validation.Constraint;
+import jakarta.validation.Payload;
+
 import java.lang.annotation.Documented;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
-
-import javax.validation.Constraint;
-import javax.validation.Payload;
 
 /**
  * Bean validation for ISO currency codes.

--- a/src/main/java/com/prowidesoftware/swift/constraints/CurrencyValidator.java
+++ b/src/main/java/com/prowidesoftware/swift/constraints/CurrencyValidator.java
@@ -16,10 +16,9 @@
 package com.prowidesoftware.swift.constraints;
 
 import com.prowidesoftware.swift.utils.IsoUtils;
+import jakarta.validation.ConstraintValidator;
+import jakarta.validation.ConstraintValidatorContext;
 import org.apache.commons.lang3.StringUtils;
-
-import javax.validation.ConstraintValidator;
-import javax.validation.ConstraintValidatorContext;
 
 /**
  * Implementation of the ISO currency code validation constraint

--- a/src/main/java/com/prowidesoftware/swift/constraints/IbanConstraint.java
+++ b/src/main/java/com/prowidesoftware/swift/constraints/IbanConstraint.java
@@ -17,13 +17,13 @@ package com.prowidesoftware.swift.constraints;
 
 import static java.lang.annotation.ElementType.*;
 
+import jakarta.validation.Constraint;
+import jakarta.validation.Payload;
+
 import java.lang.annotation.Documented;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
-
-import javax.validation.Constraint;
-import javax.validation.Payload;
 
 /**
  * Bean validation for IBAN numbers.

--- a/src/main/java/com/prowidesoftware/swift/constraints/IbanValidator.java
+++ b/src/main/java/com/prowidesoftware/swift/constraints/IbanValidator.java
@@ -17,10 +17,9 @@ package com.prowidesoftware.swift.constraints;
 
 import com.prowidesoftware.swift.model.IBAN;
 import com.prowidesoftware.swift.model.IbanValidationResult;
+import jakarta.validation.ConstraintValidator;
+import jakarta.validation.ConstraintValidatorContext;
 import org.apache.commons.lang3.StringUtils;
-
-import javax.validation.ConstraintValidator;
-import javax.validation.ConstraintValidatorContext;
 
 /**
  * Implementation of the IBAN validation constraint

--- a/src/main/java/com/prowidesoftware/swift/model/AbstractSwiftMessage.java
+++ b/src/main/java/com/prowidesoftware/swift/model/AbstractSwiftMessage.java
@@ -21,6 +21,8 @@ import com.prowidesoftware.JsonSerializable;
 import com.prowidesoftware.deprecation.ProwideDeprecated;
 import com.prowidesoftware.deprecation.TargetYear;
 import com.prowidesoftware.swift.utils.Lib;
+import jakarta.persistence.*;
+import jakarta.xml.bind.annotation.XmlTransient;
 import org.apache.commons.lang3.ArrayUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.lang3.Validate;
@@ -32,9 +34,6 @@ import java.io.Serializable;
 import java.math.BigDecimal;
 import java.text.NumberFormat;
 import java.util.*;
-
-import javax.persistence.*;
-import javax.xml.bind.annotation.XmlTransient;
 
 /**
  * Base entity for MT and MX message persistence.

--- a/src/main/java/com/prowidesoftware/swift/model/MtSwiftMessage.java
+++ b/src/main/java/com/prowidesoftware/swift/model/MtSwiftMessage.java
@@ -24,6 +24,9 @@ import com.prowidesoftware.swift.io.ConversionService;
 import com.prowidesoftware.swift.model.mt.AbstractMT;
 import com.prowidesoftware.swift.model.mt.DefaultMtMetadataStrategy;
 import com.prowidesoftware.swift.model.mt.MTVariant;
+import jakarta.persistence.Column;
+import jakarta.persistence.DiscriminatorValue;
+import jakarta.persistence.Entity;
 import org.apache.commons.lang3.EnumUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.lang3.Validate;
@@ -35,10 +38,6 @@ import java.util.Calendar;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.logging.Level;
-
-import javax.persistence.Column;
-import javax.persistence.DiscriminatorValue;
-import javax.persistence.Entity;
 
 
 /**

--- a/src/main/java/com/prowidesoftware/swift/model/SwiftMessageNote.java
+++ b/src/main/java/com/prowidesoftware/swift/model/SwiftMessageNote.java
@@ -15,9 +15,9 @@
  */
 package com.prowidesoftware.swift.model;
 
-import java.util.Calendar;
+import jakarta.persistence.*;
 
-import javax.persistence.*;
+import java.util.Calendar;
 
 /**
  * Comments associated to a message for application only usage (not part of the standard).

--- a/src/main/java/com/prowidesoftware/swift/model/SwiftMessageRevision.java
+++ b/src/main/java/com/prowidesoftware/swift/model/SwiftMessageRevision.java
@@ -15,12 +15,12 @@
  */
 package com.prowidesoftware.swift.model;
 
-import static javax.persistence.FetchType.LAZY;
+import static jakarta.persistence.FetchType.LAZY;
+
+import jakarta.persistence.*;
 
 import java.util.Calendar;
 import java.util.Objects;
-
-import javax.persistence.*;
 
 /**
  * A revision is a snapshot of message content and is used to track the history of changes in a message.

--- a/src/main/java/com/prowidesoftware/swift/model/SwiftMessageStatusInfo.java
+++ b/src/main/java/com/prowidesoftware/swift/model/SwiftMessageStatusInfo.java
@@ -15,12 +15,12 @@
  */
 package com.prowidesoftware.swift.model;
 
-import static javax.persistence.FetchType.LAZY;
+import static jakarta.persistence.FetchType.LAZY;
+
+import jakarta.persistence.*;
 
 import java.util.Calendar;
 import java.util.Objects;
-
-import javax.persistence.*;
 
 /**
  * Status tracking record for application only usage (not part of the standard).<br>


### PR DESCRIPTION
## Motivation

Many frameworks like Spring Boot, Quarkus, Camel... have made the Jakarta EE 10 migration which makes the lib incompatible with them. The goal of these changes is to migrate the lib to make it compatible again with the frameworks.

## Modifications:

* Replace the Javax dependencies with the corresponding Jakarta dependencies
* Replace the `javax` imports with the corresponding `jakarta` imports
* Reorganize the imports to have them at the right place