### PR TITLE
Migration to Java 11

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -36,7 +36,7 @@ project.version = "${SRU}-${scmVersion.version}"
 
 java {
     toolchain {
-        languageVersion.set(JavaLanguageVersion.of(8))
+        languageVersion.set(JavaLanguageVersion.of(11))
     }
 }
 tasks.withType(JavaCompile) {

--- a/src/test/java/com/prowidesoftware/swift/io/parser/SwiftParserConsumeBlockLenientTest.java
+++ b/src/test/java/com/prowidesoftware/swift/io/parser/SwiftParserConsumeBlockLenientTest.java
@@ -319,7 +319,7 @@ public class SwiftParserConsumeBlockLenientTest {
         assertEquals("00112233", b.getTagValue("108"));
         assertTrue(b.containsTag("4"));
         assertEquals("foobar", b.getTagValue("4"));
-        assertEquals(b.getUnparsedTextsSize(), new Integer(1));
+        assertEquals(b.getUnparsedTextsSize(), Integer.valueOf(1));
         assertEquals(b.unparsedTextGetText(0), "blockdata");
     }
 

--- a/src/test/java/com/prowidesoftware/swift/model/UnparsedTextListTest.java
+++ b/src/test/java/com/prowidesoftware/swift/model/UnparsedTextListTest.java
@@ -58,7 +58,7 @@ public class UnparsedTextListTest {
     @Test
     public void test_addText() {
         t.addText(someText);
-        assertEquals(t.size(), new Integer(1));
+        assertEquals(t.size(), Integer.valueOf(1));
         assertEquals(t.getText(0), someText);
     }
 
@@ -72,9 +72,9 @@ public class UnparsedTextListTest {
 
     @Test
     public void test_size() {
-        assertEquals(t.size(), new Integer(0));
+        assertEquals(t.size(), Integer.valueOf(0));
         t.addText(someText);
-        assertEquals(t.size(), new Integer(1));
+        assertEquals(t.size(), Integer.valueOf(1));
     }
 
     @Test
@@ -113,7 +113,7 @@ public class UnparsedTextListTest {
         t.addText(msg);
 
         // check things out
-        assertEquals(t.size(), new Integer(1));
+        assertEquals(t.size(), Integer.valueOf(1));
         assertEquals(t.getText(0), msgString);
     }
 
@@ -123,7 +123,7 @@ public class UnparsedTextListTest {
         t.addText(someMsg);
         t.removeText(0);
         assertEquals(t.getText(0), someMsg);
-        assertEquals(t.size(), new Integer(1));
+        assertEquals(t.size(), Integer.valueOf(1));
     }
 
     @Test
@@ -137,7 +137,7 @@ public class UnparsedTextListTest {
         t.addText(someMsg);
         t.removeText(someText);
         assertEquals(t.getText(0), someMsg);
-        assertEquals(t.size(), new Integer(1));
+        assertEquals(t.size(), Integer.valueOf(1));
     }
 
     @Test

--- a/src/test/java/com/prowidesoftware/swift/model/field/FieldComponentLabelsCompatibilityTest.java
+++ b/src/test/java/com/prowidesoftware/swift/model/field/FieldComponentLabelsCompatibilityTest.java
@@ -51,8 +51,8 @@ public class FieldComponentLabelsCompatibilityTest {
         int missing = 0;
         int availableOK = 0;
         int availableError = 0;
-        for (Class c : classes) {
-            Field f = (Field) c.newInstance();
+        for (Class<?> c : classes) {
+            Field f = (Field) c.getDeclaredConstructor().newInstance();
             int size = f.getComponents().size();
             final String label = Field.getLabelComponents(f.getName(), null, null, null);
             if (label.endsWith(".components")) {

--- a/src/test/java/com/prowidesoftware/swift/utils/SwiftFormatUtilsTest.java
+++ b/src/test/java/com/prowidesoftware/swift/utils/SwiftFormatUtilsTest.java
@@ -42,22 +42,22 @@ public class SwiftFormatUtilsTest {
         //this test does not work but this format is not used
 
         assertNotNull(SwiftFormatUtils.getNumber("1,2"));
-        assertEquals(new Double(1.2), new Double(SwiftFormatUtils.getNumber("1,2").doubleValue()));
+        assertEquals(Double.valueOf(1.2), Double.valueOf(SwiftFormatUtils.getNumber("1,2").doubleValue()));
 
         assertNotNull(SwiftFormatUtils.getNumber("12,34"));
-        assertEquals(new Double(12.34), new Double(SwiftFormatUtils.getNumber("12,34").doubleValue()));
+        assertEquals(Double.valueOf(12.34), Double.valueOf(SwiftFormatUtils.getNumber("12,34").doubleValue()));
 
         assertNotNull(SwiftFormatUtils.getNumber("12,3456"));
-        assertEquals(new Double(12.3456), new Double(SwiftFormatUtils.getNumber("12,3456").doubleValue()));
+        assertEquals(Double.valueOf(12.3456), Double.valueOf(SwiftFormatUtils.getNumber("12,3456").doubleValue()));
 
         assertNotNull(SwiftFormatUtils.getNumber("0,"));
-        assertEquals(new Double(0), new Double(SwiftFormatUtils.getNumber("0,").doubleValue()));
+        assertEquals(Double.valueOf(0), Double.valueOf(SwiftFormatUtils.getNumber("0,").doubleValue()));
 
         assertNotNull(SwiftFormatUtils.getNumber("299000,34"));
-        assertEquals(new Double(299000.34), new Double(SwiftFormatUtils.getNumber("299000,34").doubleValue()));
+        assertEquals(Double.valueOf(299000.34), Double.valueOf(SwiftFormatUtils.getNumber("299000,34").doubleValue()));
 
         assertNotNull(SwiftFormatUtils.getNumber(",34"));
-        assertEquals(new Double(0.34), new Double(SwiftFormatUtils.getNumber(",34").doubleValue()));
+        assertEquals(Double.valueOf(0.34), Double.valueOf(SwiftFormatUtils.getNumber(",34").doubleValue()));
     }
 
     @Test


### PR DESCRIPTION
## Motivation

Many frameworks like Spring Boot, Quarkus, Camel... have made the Jakarta EE 10 migration which makes the lib incompatible with them. The goal of these changes is to prepare the lib to the Jakarta EE 10 migration by upgrading first the version of Java.

## Modifications:

* Change the default Java version to 11
* Fix warnings related to the migration to Java 11