### PR TITLE
CU-86b1uerqp_Generar-un-enum-de-MTs-para-validar-sus-secuencias-y-paths

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Prowide Core - CHANGELOG
 
+#### 9.4.19 - SNAPSHOT
+  * Added new `MtSequenceEnum` with all the available inner sequences of specific MT schemas
+
 #### 9.4.18 - October 2024
   * Added new `FieldEnum` with all the available field names
   * Code security improvements as per CodeQL recommendations

--- a/src/generated/java/com/prowidesoftware/swift/model/field/FieldEnum.java
+++ b/src/generated/java/com/prowidesoftware/swift/model/field/FieldEnum.java
@@ -16,11 +16,14 @@
 
 package com.prowidesoftware.swift.model.field;
 
+import com.prowidesoftware.Generated;
+
 /**
 * Enumeration of fields for SRU 2023
 *
 * @since 9.4.18
 */
+@Generated
 public enum FieldEnum {
 
     F11A,

--- a/src/generated/java/com/prowidesoftware/swift/model/mt/MtSequenceEnum.java
+++ b/src/generated/java/com/prowidesoftware/swift/model/mt/MtSequenceEnum.java
@@ -1,0 +1,142 @@
+/*
+* Copyright 2006-2024 Prowide
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+package com.prowidesoftware.swift.model.mt;
+
+import com.prowidesoftware.Generated;
+
+import java.util.Arrays;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+/**
+* Enumeration representing all possible sequence paths for each MT (Message Type) schema.
+* Each constant in this enumeration corresponds to a specific MT schema, identified by its
+* sequence paths as a comma-separated string (CSV) for SRU 2023.
+*
+* <p>For example, the MT508 message type may have sequence paths such as "A", "A/A1", "B", "B/B1", and "C",
+* which would be represented as the CSV string "A,A/A1,B,B/B1,C".
+* Note that internal loops not clearly identified and named in the standard as a sequence, are excluded.
+*
+* <p>For example, the MT801 message contains the "Loop1" and "Loop2" sequences, and this are not included in the sequence paths.
+*
+* @since 9.4.18
+*/
+@Generated
+public enum MtSequenceEnum {
+
+    MT101("A,B"),
+    MT102("A,B,C"),
+    MT102_STP("A,B,C"),
+    MT104("A,B,C"),
+    MT107("A,B,C"),
+    MT202COV("A,B"),
+    MT204("A,B"),
+    MT205COV("A,B"),
+    MT300("A,B,B/B1,B/B2,C,D,D/D1,E,E/E1,E/E1/E1a,E/E1/E1a/E1a1,F"),
+    MT304("A,B,B/B1,B/B2,C,C/C1,C/C1/C1a,D,E"),
+    MT305("A,B,B/B1,B/B1/B1a,B/B1/B1a/B1a1"),
+    MT306("A,B,B/B1,B/B2,C,D,E,F,F/F1,G,H,I,J,J/J1,J/J2,K,L,M,M/M1,M/M1/M1a,M/M1/M1a/M1a1"),
+    MT320("A,B,C,D,E,F,G,H,I"),
+    MT321("A,A/A1,B,B/B1,B/B2,B/B3,C,C/C1"),
+    MT330("A,B,C,D,E,F,G,H"),
+    MT340("A,B,B/B1,B/B2,C,D,E,F,G,G/G1,G/G1/G1a,G/G1/G1a/G1a1"),
+    MT341("A,B,B/B1,C,D,D/D1,D/D1/D1a,D/D1/D1a/D1a1"),
+    MT350("A,B,C,D,D/D1,D/D2"),
+    MT360("A,B,B/B1,C,C/C1,C/C2,C/C3,D,E,E/E1,F,F/F1,F/F2,F/F3,G,H,L,M,N,O,O/O1,O/O1/O1a,O/O1/O1a/O1a1"),
+    MT361("A,B,B/B1,C,C/C1,C/C2,C/C3,D,E,E/E1,F,F/F1,F/F2,F/F3,G,H,I,J,K,L,M,N,O,P,P/P1,P/P1/P1a,P/P1/P1a/P1a1"),
+    MT362("A,B,C,D,E"),
+    MT364("A,B,E,L,M"),
+    MT365("A,B,E,J,K,L,M"),
+    MT370("A,A/A1,A/A2,B,B/B1"),
+    MT380("A,A/A1,B,B/B1,B/B2,C"),
+    MT381("A,A/A1,B,B/B1,B/B2,C"),
+    MT416("A,B"),
+    MT430("A,B"),
+    MT500("A,A/A1,B,B/B1,B/B2,C,C/C1,C/C2,D,E"),
+    MT501("A,A/A1,B,B/B1,B/B2,C,C/C1,C/C2,D,E"),
+    MT502("A,A/A1,B,B/B1,B/B2,B/B3,C,C/C1,C/C2,C/C3,D,E"),
+    MT503("A,A/A1,A/A2,B,B/B1,C,C/C1,C/C2,C/C3,D"),
+    MT504("A,A/A1,A/A2,B,B/B1,C,C/C1,C/C1/C1a,C/C1/C1a/C1a1,C/C2,C/C2/C2a,C/C2/C2a/C2a1,C/C3,D,D/D1,E,E/E1,F"),
+    MT505("A,A/A1,A/A2,B,B/B1,B/B1/B1a,B/B1/B1a/B1a1,B/B2,B/B2/B2a,B/B2/B2a/B2a1,B/B3,C,C/C1,D,D/D1,E"),
+    MT506("A,A/A1,A/A2,B,B/B1,C,C/C1,C/C2,C/C3,D,D/D1,D/D2,D/D3,E"),
+    MT507("A,A/A1,A/A2,B,B/B1,B/B1/B1a,B/B1/B1a/B1a1,B/B1/B1b,B/B1/B1b/B1b1,C"),
+    MT508("A,A/A1,B,B/B1,C"),
+    MT509("A,A/A1,A/A2,A/A2/A2a,B,B/B1,C"),
+    MT510("A,A/A1,A/A2,A/A2/A2a,B,C"),
+    MT513("A,A/A1,B,B/B1,C,C/C1,C/C2,C/C3,D,D/D1,D/D2,D/D3,E,F"),
+    MT514("A,A/A1,B,B/B1,B/B2,C,C/C1,C/C2,C/C3,D,E"),
+    MT515("A,A/A1,B,C,C/C1,C/C2,D,D/D1,D/D2,D/D3,E,F"),
+    MT516("A,B,C"),
+    MT517("A,A/A1"),
+    MT518("A,A/A1,B,B/B1,B/B2,C,C/C1,C/C2,C/C3,D,E"),
+    MT519("A,A/A1,B,B/B1,B/B2,C,C/C1,C/C2,D"),
+    MT524("A,A/A1,B,B/B1,C"),
+    MT526("A,B"),
+    MT527("A,A/A1,A/A2,B,B/B1,C,D,E"),
+    MT530("A,B,B/B1,C,C/C1,C/C1/C1a"),
+    MT535("A,A/A1,B,B/B1,B/B1/B1a,B/B1/B1b,B/B1/B1b/B1b1,B/B1/B1c,C"),
+    MT536("A,A/A1,B,B/B1,B/B1/B1a,B/B1/B1a/B1a1,B/B1/B1a/B1a2,B/B1/B1a/B1a2/B1a2A,C"),
+    MT537("A,A/A1,B,B/B1,B/B2,B/B2/B2a,B/B2/B2b,B/B2/B2b/B2b1,C,C/C1,C/C2,C/C2/C2a,C/C3,C/C3/C3a,D,D/D1,D/D1/D1a,D/D1/D1a/D1a1,D/D1/D1a/D1a1/D1a1A,D/D1/D1a/D1a1/D1a1A/D1a1A1,D/D1/D1a/D1a1/D1a1B,D/D1/D1a/D1a1/D1a1B/D1a1B1,D/D1/D1a/D1a1/D1a1B/D1a1B1/D1a1B1a,D/D1/D1a/D1a1/D1a1B/D1a1B1/D1a1B1a/D1a1B1a1,E"),
+    MT538("A,A/A1,B,B/B1,B/B2,B/B2/B2a,B/B2/B2a/B2a1,C"),
+    MT540("A,A/A1,B,B/B1,C,C/C1,D,E,E/E1,E/E2,E/E3,F"),
+    MT541("A,A/A1,B,B/B1,C,C/C1,D,E,E/E1,E/E2,E/E3,F"),
+    MT542("A,A/A1,B,B/B1,C,C/C1,D,E,E/E1,E/E2,E/E3,F"),
+    MT543("A,A/A1,B,B/B1,C,C/C1,D,E,E/E1,E/E2,E/E3,F"),
+    MT544("A,A/A1,B,B/B1,C,C/C1,D,E,E/E1,E/E2,E/E3,F"),
+    MT545("A,A/A1,B,B/B1,C,C/C1,D,E,E/E1,E/E2,E/E3,F"),
+    MT546("A,A/A1,B,B/B1,C,C/C1,D,E,E/E1,E/E2,E/E3,F"),
+    MT547("A,A/A1,B,B/B1,C,C/C1,D,E,E/E1,E/E2,E/E3,F"),
+    MT548("A,A/A1,A/A2,A/A2/A2a,B,B/B1,C,C/C1,C/C1/C1a,C/C1/C1a/C1a1,C/C1/C1a/C1a1/C1a1A,C/C1/C1a/C1a1/C1a1A/C1a1A1,C/C1/C1a/C1a1/C1a1B,C/C1/C1a/C1a1/C1a1B/C1a1B1,C/C1/C1a/C1a1/C1a1B/C1a1B1/C1a1B1a,C/C1/C1a/C1a1/C1a1B/C1a1B1/C1a1B1a/C1a1B1a1,D"),
+    MT549("A,A/A1,B,C,D"),
+    MT558("A,A/A1,A/A2,A/A2/A2a,A/A3,B,B/B1,C,D,E"),
+    MT564("A,A/A1,B,B/B1,B/B2,C,D,E,E/E1,E/E1/E1a,E/E2,F"),
+    MT565("A,A/A1,B,B/B1,B/B2,C,D,E"),
+    MT566("A,A/A1,B,B/B1,C,D,D/D1,D/D1/D1a,D/D1/D1b,D/D2,D/D2/D2a,D/D2/D2b,E"),
+    MT567("A,A/A1,A/A2,A/A2/A2a,B,C"),
+    MT568("A,A/A1,B,B/B1,C"),
+    MT569("A,A/A1,A/A2,B,C,C/C1,C/C1/C1a,C/C1/C1a/C1a1,C/C1/C1a/C1a1/C1a1A,D"),
+    MT575("A,A/A1,B,B/B1,B/B1/B1a,B/B1/B1a/B1a1,B/B1/B1a/B1a2,B/B1/B1a/B1a3,B/B1/B1a/B1a4,C,C/C1,C/C2,C/C2/C2a,D"),
+    MT576("A,A/A1,B,B/B1,B/B2,B/B2/B2a,B/B2/B2b,B/B2/B2c,C"),
+    MT578("A,A/A1,B,B/B1,C,C/C1,D,E,E/E1,E/E2,E/E3,F"),
+    MT586("A,A/A1,B,B/B1,B/B2,B/B3,B/B4,B/B4/B4a,B/B5,B/B6,B/B6/B6a,B/B6/B6b,C"),
+    MT600("A,B,C,D,D/D1,D/D1/D1a,D/D1/D1a/D1a1"),
+    MT601("A,B,B/B1,B/B1/B1a,B/B1/B1a/B1a1"),
+    MT620("A,B,C,D,E,F,G,G/G1,G/G2,H"),
+    MT670("A,A/A1,A/A2,B,B/B1,B/B2,C"),
+    MT671("A,A/A1,B,B/B1,B/B2,C"),
+    MT760("A,B,C"),
+    MT767("A,B,C");
+
+    private final String sequences;
+
+    MtSequenceEnum(String sequences) {
+        this.sequences = sequences;
+    }
+
+    /**
+    * Returns the sequence paths for this MT schema.
+    * Each sequence path represents a hierarchical structure within the MT schema.
+    *
+    * @return A Set of sequence paths.
+    *
+    */
+    public Set<String> sequences() {
+        return Arrays.stream(sequences.split(","))
+            .collect(Collectors.toSet());
+    }
+
+}

--- a/src/test/java/com/prowidesoftware/swift/model/field/FieldEnumTest.java
+++ b/src/test/java/com/prowidesoftware/swift/model/field/FieldEnumTest.java
@@ -3,20 +3,48 @@ package com.prowidesoftware.swift.model.field;
 import static org.junit.jupiter.api.Assertions.*;
 
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.params.ParameterizedTest;
-import org.junit.jupiter.params.provider.CsvSource;
 
 class FieldEnu5mTest {
 
-    @ParameterizedTest
-    @CsvSource({"F11A,11A", "F22J,22J", "F44H,44H"})
-    void testFieldName(FieldEnum field, String expectedName) {
+    @Test
+    void testFieldName_F11A() {
+        FieldEnum field = FieldEnum.F11A;
+        String expectedName = "11A";
         assertEquals(expectedName, field.fieldName());
     }
 
-    @ParameterizedTest
-    @CsvSource({"11A,F11A", "22J,F22J", "44H,F44H"})
-    void testFromFieldNameValid(String fieldName, FieldEnum expectedEnum) {
+    @Test
+    void testFieldName_F22J() {
+        FieldEnum field = FieldEnum.F22J;
+        String expectedName = "22J";
+        assertEquals(expectedName, field.fieldName());
+    }
+
+    @Test
+    void testFieldName_F44H() {
+        FieldEnum field = FieldEnum.F44H;
+        String expectedName = "44H";
+        assertEquals(expectedName, field.fieldName());
+    }
+
+    @Test
+    void testFromFieldNameValid_11A() {
+        String fieldName = "11A";
+        FieldEnum expectedEnum = FieldEnum.F11A;
+        assertEquals(expectedEnum, FieldEnum.fromFieldName(fieldName));
+    }
+
+    @Test
+    void testFromFieldNameValid_22J() {
+        String fieldName = "22J";
+        FieldEnum expectedEnum = FieldEnum.F22J;
+        assertEquals(expectedEnum, FieldEnum.fromFieldName(fieldName));
+    }
+
+    @Test
+    void testFromFieldNameValid_44H() {
+        String fieldName = "44H";
+        FieldEnum expectedEnum = FieldEnum.F44H;
         assertEquals(expectedEnum, FieldEnum.fromFieldName(fieldName));
     }
 

--- a/src/test/java/com/prowidesoftware/swift/model/mt/MtSequenceEnumTest.java
+++ b/src/test/java/com/prowidesoftware/swift/model/mt/MtSequenceEnumTest.java
@@ -7,6 +7,10 @@ import java.util.HashSet;
 import java.util.Set;
 import org.junit.jupiter.api.Test;
 
+/**
+ * Unit tests for {@link MtSequenceEnum} to validate the sequence definitions
+ * and format compliance for different SWIFT MT message types.
+ */
 class MtSequenceEnumTest {
 
     private static final String SEQUENCE_PATTERN = "^[A-Z](?:/[A-Z][0-9]?(?:[a-z][0-9]?[A-Za-z0-9]*)?)*$";

--- a/src/test/java/com/prowidesoftware/swift/model/mt/MtSequenceEnumTest.java
+++ b/src/test/java/com/prowidesoftware/swift/model/mt/MtSequenceEnumTest.java
@@ -1,0 +1,100 @@
+package com.prowidesoftware.swift.model.mt;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.Set;
+import org.junit.jupiter.api.Test;
+
+class MtSequenceEnumTest {
+
+    private static final String SEQUENCE_PATTERN = "^[A-Z](?:/[A-Z][0-9]?(?:[a-z][0-9]?[A-Za-z0-9]*)?)*$";
+
+    @Test
+    void testGetSequences_MT101() {
+        MtSequenceEnum sequence = MtSequenceEnum.MT101;
+        Set<String> expectedSequences = new HashSet<>(Arrays.asList("A", "B"));
+        assertEquals(expectedSequences, sequence.sequences());
+    }
+
+    @Test
+    void testGetSequences_MT102() {
+        MtSequenceEnum sequence = MtSequenceEnum.MT102;
+        Set<String> expectedSequences = new HashSet<>(Arrays.asList("A", "B", "C"));
+        assertEquals(expectedSequences, sequence.sequences());
+    }
+
+    @Test
+    void testGetSequences_MT300() {
+        MtSequenceEnum sequence = MtSequenceEnum.MT300;
+        Set<String> expectedSequences = new HashSet<>(Arrays.asList(
+                "A", "B", "B/B1", "B/B2", "C", "D", "D/D1", "E", "E/E1", "E/E1/E1a", "E/E1/E1a/E1a1", "F"));
+        assertEquals(expectedSequences, sequence.sequences());
+    }
+
+    @Test
+    void testGetSequences_MT508() {
+        MtSequenceEnum sequence = MtSequenceEnum.MT508;
+        Set<String> expectedSequences = new HashSet<>(Arrays.asList("A", "A/A1", "B", "B/B1", "C"));
+        assertEquals(expectedSequences, sequence.sequences());
+    }
+
+    @Test
+    void testFromFieldNameValid_MT101() {
+        String fieldName = "MT101";
+        MtSequenceEnum expectedEnum = MtSequenceEnum.MT101;
+        assertEquals(expectedEnum, MtSequenceEnum.valueOf(fieldName));
+    }
+
+    @Test
+    void testFromFieldNameValid_MT102() {
+        String fieldName = "MT102";
+        MtSequenceEnum expectedEnum = MtSequenceEnum.MT102;
+        assertEquals(expectedEnum, MtSequenceEnum.valueOf(fieldName));
+    }
+
+    @Test
+    void testFromFieldNameValid_MT508() {
+        String fieldName = "MT508";
+        MtSequenceEnum expectedEnum = MtSequenceEnum.MT508;
+        assertEquals(expectedEnum, MtSequenceEnum.valueOf(fieldName));
+    }
+
+    @Test
+    void testFromFieldNameInvalid() {
+        assertThrows(NullPointerException.class, () -> MtSequenceEnum.valueOf(null));
+        assertThrows(IllegalArgumentException.class, () -> MtSequenceEnum.valueOf("INVALID"));
+        assertThrows(IllegalArgumentException.class, () -> MtSequenceEnum.valueOf(""));
+        assertThrows(IllegalArgumentException.class, () -> MtSequenceEnum.valueOf("MT"));
+        assertThrows(IllegalArgumentException.class, () -> MtSequenceEnum.valueOf("MT999999"));
+        assertThrows(IllegalArgumentException.class, () -> MtSequenceEnum.valueOf("MTxxx"));
+    }
+
+    @Test
+    void testAllEnumValuesHaveSequences() {
+        for (MtSequenceEnum seqValue : MtSequenceEnum.values()) {
+            String enumName = seqValue.name();
+            assertNotNull(seqValue.sequences(), String.format("Sequence for enum value '%s' is null", enumName));
+            assertFalse(
+                    seqValue.sequences().isEmpty(),
+                    String.format("Sequence for enum value '%s' is empty. Expected at least one sequence.", enumName));
+
+            // Validate sequence format
+            Set<String> sequences = seqValue.sequences();
+            for (String sequence : sequences) {
+                assertTrue(
+                        sequence.matches(SEQUENCE_PATTERN),
+                        String.format(
+                                "Sequence '%s' in %s should match format: %s", sequence, enumName, SEQUENCE_PATTERN));
+            }
+
+            // Check for duplicates
+            Set<String> uniqueSequences = new HashSet<>(sequences);
+            assertEquals(
+                    sequences.size(),
+                    uniqueSequences.size(),
+                    String.format("Sequences in %s contain duplicates: %s", enumName, sequences));
+        }
+    }
+}

--- a/src/test/java/com/prowidesoftware/swift/model/mt/MtSequenceEnumTest.java
+++ b/src/test/java/com/prowidesoftware/swift/model/mt/MtSequenceEnumTest.java
@@ -13,6 +13,14 @@ import org.junit.jupiter.api.Test;
  */
 class MtSequenceEnumTest {
 
+    /**
+     * Regex pattern for validating SWIFT MT sequence formats.
+     * Valid examples:
+     * - "A"           (simple sequence)
+     * - "B/B1"        (sequence with numeric suffix)
+     * - "E/E1/E1a"    (nested sequence)
+     * - "E/E1a/E1a1"  (complex nested sequence)
+     */
     private static final String SEQUENCE_PATTERN = "^[A-Z](?:/[A-Z][0-9]?(?:[a-z][0-9]?[A-Za-z0-9]*)?)*$";
 
     @Test


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced `MtSequenceEnum` to enumerate inner sequences of specific MT schemas.
- **Bug Fixes**
	- Ongoing code security improvements based on CodeQL recommendations.
- **Tests**
	- Added a comprehensive suite of unit tests for `MtSequenceEnum`, validating functionality and handling of valid/invalid inputs.
	- Refined `FieldEnumTest` by replacing parameterized tests with individual test methods for improved clarity and structure.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->