### PR TITLE
(PW-2055) Refactor MT metadata extraction for ACK/NAK

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Prowide Core - CHANGELOG
 
+#### 10.2.7 - SNAPSHOT
+  * (PW-2055) Fixed the default message metadata extraction for ACK/NAK to set the service message block 1 BIC as receiver, not as sender
+  * (PW-2055) Enhanced the `SwiftMessageUtils` extractors to support the service 21 message type (ACK/NAK)
+  * (PW-2055) Changed the extraction logic in `SwiftMessageUtils` and SwiftMessage to return the BIC11 instead of the LT address for sender and receiver
+
 #### 10.2.6 - April 2025
   * (CU-86b49rvw4) Updated label for Fields 14[P,Q,R]/16W/29[Q,W]
   * (PW-2239) BIC Branch check for all upper and lower case

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,6 @@
 #### 10.2.7 - SNAPSHOT
   * (PW-2055) Fixed the default message metadata extraction for ACK/NAK to set the service message block 1 BIC as receiver, not as sender
   * (PW-2055) Enhanced the `SwiftMessageUtils` extractors to support the service 21 message type (ACK/NAK)
-  * (PW-2055) Changed the extraction logic in `SwiftMessageUtils` and SwiftMessage to return the BIC11 instead of the LT address for sender and receiver
 
 #### 10.2.6 - April 2025
   * (CU-86b49rvw4) Updated label for Fields 14[P,Q,R]/16W/29[Q,W]

--- a/src/main/java/com/prowidesoftware/swift/model/AbstractSwiftMessage.java
+++ b/src/main/java/com/prowidesoftware/swift/model/AbstractSwiftMessage.java
@@ -55,13 +55,13 @@ public abstract class AbstractSwiftMessage implements Serializable, JsonSerializ
      *
      * @since 7.8.8
      */
-    protected static final String IDENTIFIER_ACK = "ACK";
+    public static final String IDENTIFIER_ACK = "ACK";
     /**
      * Identifier constant for non-acknowledge service messages
      *
      * @since 7.8.8
      */
-    protected static final String IDENTIFIER_NAK = "NAK";
+    public static final String IDENTIFIER_NAK = "NAK";
 
     private static final transient java.util.logging.Logger log =
             java.util.logging.Logger.getLogger(AbstractSwiftMessage.class.getName());

--- a/src/main/java/com/prowidesoftware/swift/model/SwiftMessageUtils.java
+++ b/src/main/java/com/prowidesoftware/swift/model/SwiftMessageUtils.java
@@ -134,103 +134,116 @@ public class SwiftMessageUtils {
      * <li>For MT564 returns the value date from Cash Movements Field 98a with qualifier PAYD (not qualifier VALU)</li>
      * </ul>
      *
+     * <p>For ACK/NAK messages, the value date is extracted from the original attached message, if present.
+     *
      * @param m the message where the value date is to be found
-     * @return found date or null if the message does not defines a value date, or if the defined value date field is not present in the message
+     * @return found date or null if the message does not define a value date, or if the defined value date field is not present in the message
      * @since 7.7
      */
     public static Calendar valueDate(final SwiftMessage m) {
-        if (m != null) {
-            final SwiftBlock4 b4 = m.getBlock4();
-            if (b4 != null && !b4.isEmpty()) {
-                Tag t = null;
-                Field f = null;
-                if (m.isType(101, 104, 107, 201, 203, 204, 207, 210, 604, 605)) {
-                    t = b4.getTagByName(Field30.NAME);
-                } else if (m.isType(102, 103, 200, 202, 205, 400, 450, 455, 800, 802, 900, 910)) {
-                    t = b4.getTagByName(Field32A.NAME);
-                } else if (m.isType(300, 304, 320, 330, 350, 620)) {
-                    t = b4.getTagByName(Field30V.NAME);
-                } else if (m.isType(370)) {
-                    final SwiftTagListBlock seq = b4.getSubBlock("NETPOS");
-                    if (seq != null) {
-                        f = seq.getFieldByNumber(98, "NETT");
-                    }
-                } else if (m.isType(456)) {
-                    t = b4.getTagByName(Field33D.NAME);
-                } else if (m.isType(502)) {
-                    final SwiftTagListBlock seq = b4.getSubBlock("AMT");
-                    if (seq != null) {
-                        f = seq.getFieldByNumber(98, "VALU");
-                    }
-                } else if (m.isType(509)) {
-                    final SwiftTagListBlock seq = b4.getSubBlock("TRADE");
-                    if (seq != null) {
-                        f = seq.getFieldByNumber(98, "SETT");
-                    }
-                } else if (m.isType(513)) {
-                    final SwiftTagListBlock seq = b4.getSubBlock("ORDRDET");
-                    if (seq != null) {
-                        f = seq.getFieldByNumber(98, "SETT");
-                    }
-                } else if (m.isType(514, 515, 518)) {
-                    final SwiftTagListBlock seq = b4.getSubBlock("CONFDET");
-                    if (seq != null) {
-                        f = seq.getFieldByNumber(98, "SETT");
-                    }
-                } else if (m.isType(540, 541, 542, 543, 544, 545, 546, 547, 586)) {
-                    final SwiftTagListBlock seq = b4.getSubBlock("TRADDET");
-                    if (seq != null) {
-                        f = seq.getFieldByNumber(98, "SETT");
-                    } else {
-                        final SwiftTagListBlock seq2 = b4.getSubBlock("AMT");
-                        if (seq2 != null) {
-                            f = seq2.getFieldByNumber(98, "VALU");
-                        }
-                    }
-                } else if (m.isType(537)) {
-                    final SwiftTagListBlock seq = b4.getSubBlock("TRANSDET");
-                    if (seq != null) {
-                        f = seq.getFieldByNumber(98, "EXSE");
-                    }
-                } else if (m.isType(548)) {
-                    final SwiftTagListBlock seq = b4.getSubBlock("SETTRAN");
-                    if (seq != null) {
-                        f = seq.getFieldByNumber(70, "SPRO");
-                    }
-                } else if (m.isType(564)) {
-                    final SwiftTagListBlock seq = b4.getSubBlock("CASHMOVE");
-                    if (seq != null) {
-                        f = seq.getFieldByNumber(98, "PAYD");
-                    }
-                } else if (m.isType(566)) {
-                    final SwiftTagListBlock seq = b4.getSubBlock("CASHMOVE");
-                    if (seq != null) {
-                        f = seq.getFieldByNumber(98, "POST");
-                    }
-                } else if (m.isType(730, 768, 769)) {
-                    t = b4.getTagByName(Field32D.NAME);
-                } else if (m.isType(734, 752, 756)) {
-                    t = b4.getTagByName(Field33A.NAME);
-                } else if (m.isType(742, 754)) {
-                    t = b4.getTagByName(Field34A.NAME);
-                } else if (m.isType(942, 950, 970, 972)) {
-                    t = b4.getTagByName(Field61.NAME);
-                } else if (m.isType(305)) {
-                    t = b4.getTagByName(Field31G.NAME);
-                } else if (m.isType(306)) {
-                    t = b4.getTagByName(Field30V.NAME);
-                } else if (m.isType(340, 341)) {
-                    t = b4.getTagByName(Field30F.NAME);
-                } else if (m.isType(360, 361, 362)) {
-                    t = b4.getTagByName(Field30V.NAME);
+        if (m == null) {
+            return null;
+        }
+        // for ACK/NAK, we attempt to extract the value date from the original attached message, if present
+        if (m.isServiceMessage21() && m.getUnparsedTextsSize() > 0) {
+            final SwiftMessage original = m.getUnparsedTexts().getTextAsMessage(0);
+            if (original != null) {
+                final Calendar valueDate = valueDate(original);
+                if (valueDate != null) {
+                    return valueDate;
                 }
+            }
+        }
+        final SwiftBlock4 b4 = m.getBlock4();
+        if (b4 != null && !b4.isEmpty()) {
+            Tag t = null;
+            Field f = null;
+            if (m.isType(101, 104, 107, 201, 203, 204, 207, 210, 604, 605)) {
+                t = b4.getTagByName(Field30.NAME);
+            } else if (m.isType(102, 103, 200, 202, 205, 400, 450, 455, 800, 802, 900, 910)) {
+                t = b4.getTagByName(Field32A.NAME);
+            } else if (m.isType(300, 304, 320, 330, 350, 620)) {
+                t = b4.getTagByName(Field30V.NAME);
+            } else if (m.isType(370)) {
+                final SwiftTagListBlock seq = b4.getSubBlock("NETPOS");
+                if (seq != null) {
+                    f = seq.getFieldByNumber(98, "NETT");
+                }
+            } else if (m.isType(456)) {
+                t = b4.getTagByName(Field33D.NAME);
+            } else if (m.isType(502)) {
+                final SwiftTagListBlock seq = b4.getSubBlock("AMT");
+                if (seq != null) {
+                    f = seq.getFieldByNumber(98, "VALU");
+                }
+            } else if (m.isType(509)) {
+                final SwiftTagListBlock seq = b4.getSubBlock("TRADE");
+                if (seq != null) {
+                    f = seq.getFieldByNumber(98, "SETT");
+                }
+            } else if (m.isType(513)) {
+                final SwiftTagListBlock seq = b4.getSubBlock("ORDRDET");
+                if (seq != null) {
+                    f = seq.getFieldByNumber(98, "SETT");
+                }
+            } else if (m.isType(514, 515, 518)) {
+                final SwiftTagListBlock seq = b4.getSubBlock("CONFDET");
+                if (seq != null) {
+                    f = seq.getFieldByNumber(98, "SETT");
+                }
+            } else if (m.isType(540, 541, 542, 543, 544, 545, 546, 547, 586)) {
+                final SwiftTagListBlock seq = b4.getSubBlock("TRADDET");
+                if (seq != null) {
+                    f = seq.getFieldByNumber(98, "SETT");
+                } else {
+                    final SwiftTagListBlock seq2 = b4.getSubBlock("AMT");
+                    if (seq2 != null) {
+                        f = seq2.getFieldByNumber(98, "VALU");
+                    }
+                }
+            } else if (m.isType(537)) {
+                final SwiftTagListBlock seq = b4.getSubBlock("TRANSDET");
+                if (seq != null) {
+                    f = seq.getFieldByNumber(98, "EXSE");
+                }
+            } else if (m.isType(548)) {
+                final SwiftTagListBlock seq = b4.getSubBlock("SETTRAN");
+                if (seq != null) {
+                    f = seq.getFieldByNumber(70, "SPRO");
+                }
+            } else if (m.isType(564)) {
+                final SwiftTagListBlock seq = b4.getSubBlock("CASHMOVE");
+                if (seq != null) {
+                    f = seq.getFieldByNumber(98, "PAYD");
+                }
+            } else if (m.isType(566)) {
+                final SwiftTagListBlock seq = b4.getSubBlock("CASHMOVE");
+                if (seq != null) {
+                    f = seq.getFieldByNumber(98, "POST");
+                }
+            } else if (m.isType(730, 768, 769)) {
+                t = b4.getTagByName(Field32D.NAME);
+            } else if (m.isType(734, 752, 756)) {
+                t = b4.getTagByName(Field33A.NAME);
+            } else if (m.isType(742, 754)) {
+                t = b4.getTagByName(Field34A.NAME);
+            } else if (m.isType(942, 950, 970, 972)) {
+                t = b4.getTagByName(Field61.NAME);
+            } else if (m.isType(305)) {
+                t = b4.getTagByName(Field31G.NAME);
+            } else if (m.isType(306)) {
+                t = b4.getTagByName(Field30V.NAME);
+            } else if (m.isType(340, 341)) {
+                t = b4.getTagByName(Field30F.NAME);
+            } else if (m.isType(360, 361, 362)) {
+                t = b4.getTagByName(Field30V.NAME);
+            }
 
-                if (t != null) {
-                    f = t.asField();
-                }
-                if (f != null && f instanceof DateContainer) {
-                    return ((DateContainer) f).dates().get(0);
-                }
+            if (t != null) {
+                f = t.asField();
+            }
+            if (f != null && f instanceof DateContainer) {
+                return ((DateContainer) f).dates().get(0);
             }
         }
         return null;
@@ -245,22 +258,35 @@ public class SwiftMessageUtils {
      *
      * <p>Notice a lot of messages do not define a trade date.
      *
+     * <p>For ACK/NAK messages, the trade date is extracted from the original attached message, if present.
+     *
      * @param m the message where the value date is to be found
-     * @return found date or null if the message does not defines a trade date, or if the defined trade date field is not present in the message
+     * @return found date or null if the message does not define a trade date, or if the defined trade date field is not present in the message
      * @since 7.10.4
      */
     public static Calendar tradeDate(final SwiftMessage m) {
-        if (m != null) {
-            final SwiftBlock4 b4 = m.getBlock4();
-            if (b4 != null && !b4.isEmpty()) {
+        if (m == null) {
+            return null;
+        }
+        // for ACK/NAK, we attempt to extract the trade date from the original attached message, if present
+        if (m.isServiceMessage21() && m.getUnparsedTextsSize() > 0) {
+            final SwiftMessage original = m.getUnparsedTexts().getTextAsMessage(0);
+            if (original != null) {
+                final Calendar tradeDate = tradeDate(original);
+                if (tradeDate != null) {
+                    return tradeDate;
+                }
+            }
+        }
+        final SwiftBlock4 b4 = m.getBlock4();
+        if (b4 != null && !b4.isEmpty()) {
 
-                Field f = m.getBlock4().getFieldByName(Field30T.NAME);
-                if (f == null) {
-                    f = m.getBlock4().getFieldByNumber(98, "TRAD");
-                }
-                if (f != null && f instanceof DateContainer) {
-                    return ((DateContainer) f).dates().get(0);
-                }
+            Field f = m.getBlock4().getFieldByName(Field30T.NAME);
+            if (f == null) {
+                f = m.getBlock4().getFieldByNumber(98, "TRAD");
+            }
+            if (f != null && f instanceof DateContainer) {
+                return ((DateContainer) f).dates().get(0);
             }
         }
         return null;
@@ -268,19 +294,29 @@ public class SwiftMessageUtils {
 
     /**
      * Gets the message sender BIC from the message headers.
-     * <p>For outgoing messages this is the logical terminal at block 1,
-     * and for incoming messages this is logical terminal at the MIR of block 2.
-     * <p>for service message (example acknowledges) always returns the logical terminal from block1
+     * <p>
+     * For outgoing messages this is the logical terminal at block 1, and for incoming messages this is logical
+     * terminal at the MIR of block 2.
+     * <p>
+     * For service message (example acknowledges) there is no sender address, the service messages are sent by the
+     * SWIFT interface. Anyway for convenience, this implementation attempts to extract as ACK sender the counterparty
+     * BIC from the original sent message, if present as part of the ACK payload.
      *
-     * @return the proper sender address or null if blocks 1 or 2 are not found or incomplete
+     * @return the proper sender address as BIC11 or null if blocks 1 or 2 are not found or incomplete
      * @since 9.3.19
      */
     public static String sender(final SwiftMessage m) {
         try {
-            if (m.isServiceMessage() || m.getDirection() == MessageIOType.outgoing) {
-                return m.getBlock1() == null ? null : m.getBlock1().getLogicalTerminal();
-            } else if ((m.getDirection() == MessageIOType.incoming) && (m.getBlock2() != null)) {
-                return ((SwiftBlock2Output) m.getBlock2()).getMIRLogicalTerminal();
+            if (m.isServiceMessage21() && m.getUnparsedTextsSize() > 0) {
+                final SwiftMessage original = m.getUnparsedTexts().getTextAsMessage(0);
+                if (original != null) {
+                    return asBic11(original.getReceiver());
+                }
+            }
+            if (m.getDirection() == MessageIOType.outgoing && m.getBlock1() != null) {
+                return asBic11(m.getBlock1().getLogicalTerminal());
+            } else if (m.getDirection() == MessageIOType.incoming && m.getBlock2() != null) {
+                return asBic11(((SwiftBlock2Output) m.getBlock2()).getMIRLogicalTerminal());
             }
         } catch (final Exception e) {
             log.severe("Exception occurred while retrieving sender's BIC from message data: " + e);
@@ -290,37 +326,60 @@ public class SwiftMessageUtils {
 
     /**
      * Gets the message receiver BIC from the message headers.
-     * <p>For outgoing messages this is the receiver address at block 2,
-     * and for incoming messages this is logical terminal at block 1.
-     * <p>for service message (example acknowledges) always returns null
+     * <p>
+     * For outgoing messages this is the receiver address at block 2, and for incoming messages this is logical
+     * terminal at block 1.
+     * <p>
+     * For service message (example acknowledges) always returns the logical terminal from block1, as from the
+     * application perspective acknowledges are incoming messages, thus the receiver is the sender of the original
+     * message.
      *
-     * @return the proper receiver address or null if blocks 1 or 2 are not found or incomplete
+     * @return the proper receiver address as BIC11 or null if blocks 1 or 2 are not found or incomplete
      * @since 9.3.19
      */
     public static String receiver(final SwiftMessage m) {
         try {
-            if (m.isServiceMessage()) {
-                return null;
-            } else if (m.getDirection() == MessageIOType.incoming) {
-                return m.getBlock1().getLogicalTerminal();
-            } else if (m.getDirection() == MessageIOType.outgoing) {
-                return ((SwiftBlock2Input) m.getBlock2()).getReceiverAddress();
-            } else {
-                return null;
+            if (m.isServiceMessage() && m.getBlock1() != null) {
+                return asBic11(m.getBlock1().getLogicalTerminal());
+            } else if (m.getDirection() == MessageIOType.incoming && m.getBlock1() != null) {
+                return asBic11(m.getBlock1().getLogicalTerminal());
+            } else if (m.getDirection() == MessageIOType.outgoing && m.getBlock2() != null) {
+                return asBic11(((SwiftBlock2Input) m.getBlock2()).getReceiverAddress());
             }
         } catch (final Exception e) {
             log.severe("Exception occurred while retrieving receiver's BIC from message data: " + e);
+        }
+        return null;
+    }
+
+    private static String asBic11(final String ltAddress) {
+        if (ltAddress == null) {
             return null;
         }
+        return new BIC(ltAddress).getBic11();
     }
 
     /**
      * Get a string in the form of businessprocess.messagetype.variant
      *
+     * <p>
+     * For acknowledges and negative acknowledges, the identifier is fixed to "ACK" and "NAK" respectively.
+     *
      * @return a string with the MT message type identification
      * @since 9.3.19
      */
     public static String identifier(final SwiftMessage m) {
+        if (m == null) {
+            return null;
+        }
+        // for ACK/NAK messages, we return the fixed identifiers
+        if (m.isServiceMessage21()) {
+            if (m.isAck()) {
+                return MtSwiftMessage.IDENTIFIER_ACK;
+            } else if (m.isNack()) {
+                return MtSwiftMessage.IDENTIFIER_NAK;
+            }
+        }
         try {
             return m.getMtId().id();
         } catch (final Exception e) {
@@ -498,30 +557,42 @@ public class SwiftMessageUtils {
      * Gets the message reference from field 20 (if present) or from field 20C:SEME if message category is 5.
      * If no Field20 or 20C are found and MUR is present, returns the MUR value (field 108 from block 3).
      *
+     * <p>For ACK/NAK messages, the reference is extracted from the original attached message, if present.
+     *
      * @param m the message where the reference is to be found
-     * @return found reference or null if the message does not defines a reference, or if the defined reference field is not present in the message
+     * @return found reference or null if the message does not define a reference, or if the defined reference field is not present in the message
      * @since 7.8
      */
     public static String reference(final SwiftMessage m) {
-        if (m != null) {
-            final SwiftBlock4 b4 = m.getBlock4();
-            if (b4 != null && !b4.isEmpty()) {
-                final Tag t = b4.getTagByName("20");
-                if (t != null) {
-                    return t.getValue();
-                }
-                final Field f = b4.getFieldByNumber(20, "SEME");
-                if (f != null) {
-                    return f.getComponent(2);
-                }
-                final Tag murBlock4 = b4.getTagByName("108");
-                if (murBlock4 != null) {
-                    return murBlock4.getValue();
+        if (m == null) {
+            return null;
+        }
+        // for ACK/NAK, we attempt to extract the reference from the original attached message, if present
+        if (m.isServiceMessage21() && m.getUnparsedTextsSize() > 0) {
+            final SwiftMessage original = m.getUnparsedTexts().getTextAsMessage(0);
+            if (original != null) {
+                final String reference = reference(original);
+                if (reference != null) {
+                    return reference;
                 }
             }
-            return m.getMUR();
         }
-        return null;
+        final SwiftBlock4 b4 = m.getBlock4();
+        if (b4 != null && !b4.isEmpty()) {
+            final Tag t = b4.getTagByName("20");
+            if (t != null) {
+                return t.getValue();
+            }
+            final Field f = b4.getFieldByNumber(20, "SEME");
+            if (f != null) {
+                return f.getComponent(2);
+            }
+            final Tag murBlock4 = b4.getTagByName("108");
+            if (murBlock4 != null) {
+                return murBlock4.getValue();
+            }
+        }
+        return m.getMUR();
     }
 
     /**
@@ -643,8 +714,18 @@ public class SwiftMessageUtils {
      * Keep in sync special case for 104 and 107 with MT104 and MT107 getSequenceC logic.
      */
     public static Money money(final SwiftMessage m) {
-        if (m == null || m.isServiceMessage21()) {
+        if (m == null) {
             return null;
+        }
+        // for ACK/NAK, we attempt to extract the amount from the original attached message, if present
+        if (m.isServiceMessage21() && m.getUnparsedTextsSize() > 0) {
+            final SwiftMessage original = m.getUnparsedTexts().getTextAsMessage(0);
+            if (original != null) {
+                final Money money = money(original);
+                if (money != null) {
+                    return money;
+                }
+            }
         }
         final SwiftBlock4 b4 = m.getBlock4();
         if (b4 == null || b4.isEmpty()) {

--- a/src/main/java/com/prowidesoftware/swift/model/SwiftMessageUtils.java
+++ b/src/main/java/com/prowidesoftware/swift/model/SwiftMessageUtils.java
@@ -697,6 +697,8 @@ public class SwiftMessageUtils {
      * This implementation is a work in progress and the interpretation of which field is consider
      * the main amount for each message type may change from time to time adding more cases or
      * even changing the used field.
+     * <p>
+     * For ACK/NAK messages, the amount is extracted from the original attached message, if present.
      *
      * @param m a message with some amount field
      * @return the currency and amount object extracted from the message or null if non is present or cannot be created from its fields

--- a/src/main/java/com/prowidesoftware/swift/model/SwiftMessageUtils.java
+++ b/src/main/java/com/prowidesoftware/swift/model/SwiftMessageUtils.java
@@ -302,7 +302,7 @@ public class SwiftMessageUtils {
      * SWIFT interface. Anyway for convenience, this implementation attempts to extract as ACK sender the counterparty
      * BIC from the original sent message, if present as part of the ACK payload.
      *
-     * @return the proper sender address as BIC11 or null if blocks 1 or 2 are not found or incomplete
+     * @return the proper sender LT address or null if blocks 1 or 2 are not found or incomplete
      * @since 9.3.19
      */
     public static String sender(final SwiftMessage m) {
@@ -310,13 +310,13 @@ public class SwiftMessageUtils {
             if (m.isServiceMessage21() && m.getUnparsedTextsSize() > 0) {
                 final SwiftMessage original = m.getUnparsedTexts().getTextAsMessage(0);
                 if (original != null) {
-                    return asBic11(original.getReceiver());
+                    return original.getReceiver();
                 }
             }
             if (m.getDirection() == MessageIOType.outgoing && m.getBlock1() != null) {
-                return asBic11(m.getBlock1().getLogicalTerminal());
+                return m.getBlock1().getLogicalTerminal();
             } else if (m.getDirection() == MessageIOType.incoming && m.getBlock2() != null) {
-                return asBic11(((SwiftBlock2Output) m.getBlock2()).getMIRLogicalTerminal());
+                return ((SwiftBlock2Output) m.getBlock2()).getMIRLogicalTerminal();
             }
         } catch (final Exception e) {
             log.severe("Exception occurred while retrieving sender's BIC from message data: " + e);
@@ -334,29 +334,22 @@ public class SwiftMessageUtils {
      * application perspective acknowledges are incoming messages, thus the receiver is the sender of the original
      * message.
      *
-     * @return the proper receiver address as BIC11 or null if blocks 1 or 2 are not found or incomplete
+     * @return the proper receiver LT address or null if blocks 1 or 2 are not found or incomplete
      * @since 9.3.19
      */
     public static String receiver(final SwiftMessage m) {
         try {
             if (m.isServiceMessage() && m.getBlock1() != null) {
-                return asBic11(m.getBlock1().getLogicalTerminal());
+                return m.getBlock1().getLogicalTerminal();
             } else if (m.getDirection() == MessageIOType.incoming && m.getBlock1() != null) {
-                return asBic11(m.getBlock1().getLogicalTerminal());
+                return m.getBlock1().getLogicalTerminal();
             } else if (m.getDirection() == MessageIOType.outgoing && m.getBlock2() != null) {
-                return asBic11(((SwiftBlock2Input) m.getBlock2()).getReceiverAddress());
+                return ((SwiftBlock2Input) m.getBlock2()).getReceiverAddress();
             }
         } catch (final Exception e) {
             log.severe("Exception occurred while retrieving receiver's BIC from message data: " + e);
         }
         return null;
-    }
-
-    private static String asBic11(final String ltAddress) {
-        if (ltAddress == null) {
-            return null;
-        }
-        return new BIC(ltAddress).getBic11();
     }
 
     /**

--- a/src/main/java/com/prowidesoftware/swift/model/mt/DefaultMtMetadataStrategy.java
+++ b/src/main/java/com/prowidesoftware/swift/model/mt/DefaultMtMetadataStrategy.java
@@ -69,7 +69,11 @@ public class DefaultMtMetadataStrategy implements MessageMetadataStrategy {
      */
     @Override
     public Optional<String> sender(AbstractMessage message) {
-        return Optional.ofNullable(SwiftMessageUtils.sender(asSwiftMessage(message)));
+        final String sender = SwiftMessageUtils.sender(asSwiftMessage(message));
+        if (sender != null) {
+            return Optional.of(new BIC(sender).getBic11());
+        }
+        return Optional.empty();
     }
 
     /**
@@ -78,7 +82,11 @@ public class DefaultMtMetadataStrategy implements MessageMetadataStrategy {
      */
     @Override
     public Optional<String> receiver(AbstractMessage message) {
-        return Optional.ofNullable(SwiftMessageUtils.receiver(asSwiftMessage(message)));
+        final String receiver = SwiftMessageUtils.receiver(asSwiftMessage(message));
+        if (receiver != null) {
+            return Optional.of(new BIC(receiver).getBic11());
+        }
+        return Optional.empty();
     }
 
     /**

--- a/src/main/java/com/prowidesoftware/swift/model/mt/DefaultMtMetadataStrategy.java
+++ b/src/main/java/com/prowidesoftware/swift/model/mt/DefaultMtMetadataStrategy.java
@@ -22,6 +22,10 @@ import java.util.Optional;
 /**
  * Default implementation of MT messages metadata extraction.
  *
+ * <p>
+ * The implementation uses the utility methods from {@link SwiftMessageUtils} to extract the metadata from the MT
+ * messages, including support for acknowledgements (ACKs) and negative acknowledgements (NAKs).
+ *
  * @see SwiftMessageUtils
  * @since 9.1.4
  */
@@ -61,6 +65,7 @@ public class DefaultMtMetadataStrategy implements MessageMetadataStrategy {
 
     /**
      * Extracts the MT sender, if present, using {@link SwiftMessageUtils#sender(SwiftMessage)}
+     * When found, returns the BIC11 format of the sender LT address.
      */
     @Override
     public Optional<String> sender(AbstractMessage message) {
@@ -69,6 +74,7 @@ public class DefaultMtMetadataStrategy implements MessageMetadataStrategy {
 
     /**
      * Extracts the MT receiver, if any, using {@link SwiftMessageUtils#receiver(SwiftMessage)}
+     * When found, returns the BIC11 format of the receiver LT address.
      */
     @Override
     public Optional<String> receiver(AbstractMessage message) {

--- a/src/test/java/com/prowidesoftware/swift/model/SwiftMessageTest.java
+++ b/src/test/java/com/prowidesoftware/swift/model/SwiftMessageTest.java
@@ -357,24 +357,24 @@ public class SwiftMessageTest {
     @Test
     public void testGetSenderReceiver() throws IOException {
         /*
-         * incomming
+         * incoming
          */
         SwiftMessage m = SwiftMessage.parse(
                 "{1:F01FOOBARXXAXXX0387241036}{2:O9502352060913FOOBUS22XXXX18884819330609140052N}{4:\n:20:123456\n-}");
-        assertEquals("FOOBUS22XXXX", m.getSender());
-        assertEquals("FOOBARXXAXXX", m.getReceiver());
+        assertEquals("FOOBUS22XXX", m.getSender());
+        assertEquals("FOOBARXXXXX", m.getReceiver());
         /*
          * outgoing
          */
         m = SwiftMessage.parse("{1:F01FOOBARAAAXXX3219604112}{2:I535FOOBUS22XXXXN}{4:\n:16R:GENL\n-}");
-        assertEquals("FOOBARAAAXXX", m.getSender());
-        assertEquals("FOOBUS22XXXX", m.getReceiver());
+        assertEquals("FOOBARAAXXX", m.getSender());
+        assertEquals("FOOBUS22XXX", m.getReceiver());
         /*
          * ack
          */
         m = SwiftMessage.parse("{1:F21BNPAFRPPZXXX0000000007}{4:{177:1702040914}{451:0}}");
-        assertEquals("BNPAFRPPZXXX", m.getSender());
-        assertNull(m.getReceiver());
+        assertEquals("BNPAFRPPXXX", m.getReceiver());
+        assertNull(m.getSender());
     }
 
     @Test

--- a/src/test/java/com/prowidesoftware/swift/model/SwiftMessageTest.java
+++ b/src/test/java/com/prowidesoftware/swift/model/SwiftMessageTest.java
@@ -361,19 +361,19 @@ public class SwiftMessageTest {
          */
         SwiftMessage m = SwiftMessage.parse(
                 "{1:F01FOOBARXXAXXX0387241036}{2:O9502352060913FOOBUS22XXXX18884819330609140052N}{4:\n:20:123456\n-}");
-        assertEquals("FOOBUS22XXX", m.getSender());
-        assertEquals("FOOBARXXXXX", m.getReceiver());
+        assertEquals("FOOBUS22XXXX", m.getSender());
+        assertEquals("FOOBARXXAXXX", m.getReceiver());
         /*
          * outgoing
          */
         m = SwiftMessage.parse("{1:F01FOOBARAAAXXX3219604112}{2:I535FOOBUS22XXXXN}{4:\n:16R:GENL\n-}");
-        assertEquals("FOOBARAAXXX", m.getSender());
-        assertEquals("FOOBUS22XXX", m.getReceiver());
+        assertEquals("FOOBARAAAXXX", m.getSender());
+        assertEquals("FOOBUS22XXXX", m.getReceiver());
         /*
          * ack
          */
         m = SwiftMessage.parse("{1:F21BNPAFRPPZXXX0000000007}{4:{177:1702040914}{451:0}}");
-        assertEquals("BNPAFRPPXXX", m.getReceiver());
+        assertEquals("BNPAFRPPZXXX", m.getReceiver());
         assertNull(m.getSender());
     }
 

--- a/src/test/java/com/prowidesoftware/swift/model/SwiftMessageUtilsTest.java
+++ b/src/test/java/com/prowidesoftware/swift/model/SwiftMessageUtilsTest.java
@@ -380,8 +380,8 @@ public class SwiftMessageUtilsTest {
     void testSenderAndReceiverExtractionOutgoingMT() throws IOException {
         String fin = "{1:F01AAAAIT2TX36A0000000000}{2:I101BBBBPLPKXXXXN}{4:\n" + ":20:4C2W0S0V8AM6X7OH\n" + "-}";
         SwiftMessage sm = SwiftMessage.parse(fin);
-        assertEquals("AAAAIT2T36A", SwiftMessageUtils.sender(sm));
-        assertEquals("BBBBPLPKXXX", SwiftMessageUtils.receiver(sm));
+        assertEquals("AAAAIT2TX36A", SwiftMessageUtils.sender(sm));
+        assertEquals("BBBBPLPKXXXX", SwiftMessageUtils.receiver(sm));
     }
 
     @Test
@@ -390,15 +390,15 @@ public class SwiftMessageUtilsTest {
                 + ":20:FTR3836472 01\n"
                 + "-}\n";
         SwiftMessage sm = SwiftMessage.parse(fin);
-        assertEquals("BBBBESMMXXX", SwiftMessageUtils.sender(sm));
-        assertEquals("AAAAARYYXXX", SwiftMessageUtils.receiver(sm));
+        assertEquals("BBBBESMMAXXX", SwiftMessageUtils.sender(sm));
+        assertEquals("AAAAARYYAXXX", SwiftMessageUtils.receiver(sm));
     }
 
     @Test
     void testReceiverExtractionACK() throws IOException {
         String fin = "{1:F21AAAAUS33AXXX0344000050}{4:{177:2505291057}{451:0}{108:9CB44CDCCB763E17}}";
         SwiftMessage sm = SwiftMessage.parse(fin);
-        assertEquals("AAAAUS33XXX", SwiftMessageUtils.receiver(sm));
+        assertEquals("AAAAUS33AXXX", SwiftMessageUtils.receiver(sm));
         assertNull(SwiftMessageUtils.sender(sm));
     }
 
@@ -409,8 +409,8 @@ public class SwiftMessageUtilsTest {
                         + ":20:TBEXO200909031\n"
                         + "-}";
         SwiftMessage sm = SwiftMessage.parse(fin);
-        assertEquals("AAAAUS33XXX", SwiftMessageUtils.receiver(sm));
+        assertEquals("AAAAUS33AXXX", SwiftMessageUtils.receiver(sm));
         // ACK does not have a sender, however we parse as sender the counterparty of the original message
-        assertEquals("BBBBIDJ10J6", SwiftMessageUtils.sender(sm));
+        assertEquals("BBBBIDJ1X0J6", SwiftMessageUtils.sender(sm));
     }
 }

--- a/src/test/java/com/prowidesoftware/swift/model/SwiftMessageUtilsTest.java
+++ b/src/test/java/com/prowidesoftware/swift/model/SwiftMessageUtilsTest.java
@@ -204,7 +204,7 @@ public class SwiftMessageUtilsTest {
     }
 
     @Test
-    public void testCurrencyAmountFromMessage() throws IOException {
+    public void testAmountFromMessage() throws IOException {
         final String fin = "{1:F01CCRTIT2TX36A0000000000}{2:I101PPABPLPKXXXXN}{3:{108:YSGU193268223XXX}}{4:\n"
                 + ":20:4C2W0S0V8AM6X7OH\n"
                 + ":28D:00001/00001\n"
@@ -228,13 +228,33 @@ public class SwiftMessageUtilsTest {
     }
 
     @Test
-    public void testCurrencyAmountFromSystemMessage() throws IOException {
+    public void testAmountFromACK() throws IOException {
+        final String fin = "{1:F21BNPAFRPPZXXX0000000002}{4:{177:1702090741}{451:0}}";
+        Money money = SwiftMessageUtils.money(SwiftMessage.parse(fin));
+        assertNull(money);
+    }
+
+    @Test
+    public void testAmountFromACK2() throws IOException {
         final String fin =
                 "{1:F21BNPAFRPPZXXX0000000002}{4:{177:1702090741}{451:0}}{1:F01BNPAFRPPZXXX0000000002}{2:I103BNPAFRPPXXXXN}{3:{108:REF1}}{4:\n"
                         + ":20:WITHMUR\n"
                         + "-}{5:{MAC:ABCD1234}{CHK:ABCDEF123456}}";
         Money money = SwiftMessageUtils.money(SwiftMessage.parse(fin));
         assertNull(money);
+    }
+
+    @Test
+    public void testAmountFromACK3() throws IOException {
+        final String fin =
+                "{1:F21BNPAFRPPZXXX0000000002}{4:{177:1702090741}{451:0}}{1:F01BNPAFRPPZXXX0000000002}{2:I103BNPAFRPPXXXXN}{3:{108:REF1}}{4:\n"
+                        + ":20:WITHMUR\n"
+                        + ":32A:251019USD1000,00\n"
+                        + "-}";
+        Money money = SwiftMessageUtils.money(SwiftMessage.parse(fin));
+        assertNotNull(money);
+        assertEquals("USD", money.getCurrency());
+        assertEquals(new BigDecimal("1000.00"), money.getAmount());
     }
 
     @Test
@@ -305,9 +325,92 @@ public class SwiftMessageUtilsTest {
     }
 
     @Test
+    public void testReferenceFromACK() throws IOException {
+        final String fin =
+                "{1:F21BNPAFRPPZXXX0000000002}{4:{177:1702090741}{451:0}}{1:F01BNPAFRPPZXXX0000000002}{2:I103BNPAFRPPXXXXN}{3:{108:REF1}}{4:\n"
+                        + ":20:WITHMUR\n"
+                        + "-}{5:{MAC:ABCD1234}{CHK:ABCDEF123456}}";
+        SwiftMessage sm = SwiftMessage.parse(fin);
+        String reference = SwiftMessageUtils.reference(sm);
+        assertEquals("WITHMUR", reference);
+    }
+
+    @Test
+    public void testReferenceFromACK2() throws IOException {
+        final String fin =
+                "{1:F21BNPAFRPPZXXX0000000002}{4:{177:1702090741}{451:0}}{1:F01BNPAFRPPZXXX0000000002}{2:I103BNPAFRPPXXXXN}{3:{108:REF1}}{4:\n"
+                        + ":23E:CRED\n"
+                        + "-}{5:{MAC:ABCD1234}{CHK:ABCDEF123456}}";
+        SwiftMessage sm = SwiftMessage.parse(fin);
+        String reference = SwiftMessageUtils.reference(sm);
+        assertEquals("REF1", reference);
+    }
+
+    @Test
+    public void testReferenceFromACK3() throws IOException {
+        final String fin =
+                "{1:F21BNPAFRPPZXXX0000000002}{4:{177:1702090741}{451:0}}{1:F01BNPAFRPPZXXX0000000002}{2:I103BNPAFRPPXXXXN}{3:{108:REF1}}";
+        SwiftMessage sm = SwiftMessage.parse(fin);
+        String reference = SwiftMessageUtils.reference(sm);
+        assertEquals("REF1", reference);
+    }
+
+    @Test
+    public void testValueDateFromACK() throws IOException {
+        final String fin =
+                "{1:F21BNPAFRPPZXXX0000000002}{4:{177:1702090741}{451:0}}{1:F01BNPAFRPPZXXX0000000002}{2:I103BNPAFRPPXXXXN}{3:{108:REF1}}{4:\n"
+                        + ":20:WITHMUR\n"
+                        + ":32A:251019USD1000,00\n"
+                        + "-}{5:{MAC:ABCD1234}{CHK:ABCDEF123456}}";
+        SwiftMessage sm = SwiftMessage.parse(fin);
+        Calendar date = SwiftMessageUtils.valueDate(sm);
+        assertEquals(2025, date.get(Calendar.YEAR));
+        assertEquals(Calendar.OCTOBER, date.get(Calendar.MONTH));
+        assertEquals(19, date.get(Calendar.DAY_OF_MONTH));
+    }
+
+    @Test
     void testCalculateChecksumLength() throws IOException {
         SwiftMessage msg = SwiftMessage.parse(Lib.readResource("MT362.fin"));
         String s = calculateChecksum(msg);
         assertEquals(s.length(), 32);
+    }
+
+    @Test
+    void testSenderAndReceiverExtractionOutgoingMT() throws IOException {
+        String fin = "{1:F01AAAAIT2TX36A0000000000}{2:I101BBBBPLPKXXXXN}{4:\n" + ":20:4C2W0S0V8AM6X7OH\n" + "-}";
+        SwiftMessage sm = SwiftMessage.parse(fin);
+        assertEquals("AAAAIT2T36A", SwiftMessageUtils.sender(sm));
+        assertEquals("BBBBPLPKXXX", SwiftMessageUtils.receiver(sm));
+    }
+
+    @Test
+    void testSenderAndReceiverExtractionIncomingMT() throws IOException {
+        String fin = "{1:F01AAAAARYYAXXX8687502912}{2:O2021531051104BBBBESMMAXXX54308192420511041531N}{4:\n"
+                + ":20:FTR3836472 01\n"
+                + "-}\n";
+        SwiftMessage sm = SwiftMessage.parse(fin);
+        assertEquals("BBBBESMMXXX", SwiftMessageUtils.sender(sm));
+        assertEquals("AAAAARYYXXX", SwiftMessageUtils.receiver(sm));
+    }
+
+    @Test
+    void testReceiverExtractionACK() throws IOException {
+        String fin = "{1:F21AAAAUS33AXXX0344000050}{4:{177:2505291057}{451:0}{108:9CB44CDCCB763E17}}";
+        SwiftMessage sm = SwiftMessage.parse(fin);
+        assertEquals("AAAAUS33XXX", SwiftMessageUtils.receiver(sm));
+        assertNull(SwiftMessageUtils.sender(sm));
+    }
+
+    @Test
+    void testReceiverExtractionACKWithOriginalMessageCopy() throws IOException {
+        String fin =
+                "{1:F21AAAAUS33AXXX0344000050}{4:{177:2505291057}{451:0}}{1:F01AAAAUS33AXXX0344000050}{2:I103BBBBIDJ1X0J6N}{4:\n"
+                        + ":20:TBEXO200909031\n"
+                        + "-}";
+        SwiftMessage sm = SwiftMessage.parse(fin);
+        assertEquals("AAAAUS33XXX", SwiftMessageUtils.receiver(sm));
+        // ACK does not have a sender, however we parse as sender the counterparty of the original message
+        assertEquals("BBBBIDJ10J6", SwiftMessageUtils.sender(sm));
     }
 }

--- a/src/test/java/com/prowidesoftware/swift/model/mt/DefaultMtMetadataStrategyTest.java
+++ b/src/test/java/com/prowidesoftware/swift/model/mt/DefaultMtMetadataStrategyTest.java
@@ -112,8 +112,8 @@ class DefaultMtMetadataStrategyTest {
         // sender of the original message. From the ACK perspective, the original sender is the receiver of the ACK.
         assertEquals("AAAALT2XXXX", strategy.receiver(mt).orElse(null));
 
-        // the ACK itself (service 21) does not have a sender (it is sent by the SWIFT interface) however for conveniece
-        // we extract as sender the counterparty BIC in the origina message
+        // the ACK itself (service 21) does not have a sender (it is sent by the SWIFT interface) however for convenience
+        // we extract as sender the counterparty BIC in the original message
         assertEquals("BBBBARZZXXX", strategy.sender(mt).orElse(null));
 
         assertEquals("ACK", strategy.identifier(mt).orElse(null));

--- a/src/test/java/com/prowidesoftware/swift/model/mt/DefaultMtMetadataStrategyTest.java
+++ b/src/test/java/com/prowidesoftware/swift/model/mt/DefaultMtMetadataStrategyTest.java
@@ -1,0 +1,121 @@
+package com.prowidesoftware.swift.model.mt;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import com.prowidesoftware.swift.model.Money;
+import java.io.IOException;
+import java.math.BigDecimal;
+import java.util.Calendar;
+import org.junit.jupiter.api.Test;
+
+class DefaultMtMetadataStrategyTest {
+
+    @Test
+    public void testParseMt() throws IOException {
+        AbstractMT mt = AbstractMT.parse("{1:F01AGBLLT2XAXXX1012000002}{2:I103TESTARZZXXXXN}{3:{108:MYMUR123458}}{4:\n"
+                + ":20:TEST\n"
+                + ":32A:090903USD23453,"
+                + "-}");
+        DefaultMtMetadataStrategy strategy = new DefaultMtMetadataStrategy();
+
+        assertEquals("TEST", strategy.reference(mt).orElse(null));
+
+        Money money = strategy.amount(mt).orElse(null);
+        assertNotNull(money);
+        assertEquals("USD", money.getCurrency());
+        assertEquals(new BigDecimal("23453"), money.getAmount());
+
+        Calendar valueDate = strategy.valueDate(mt).orElse(null);
+        assertNotNull(valueDate);
+        assertEquals(2009, valueDate.get(Calendar.YEAR));
+        assertEquals(Calendar.SEPTEMBER, valueDate.get(Calendar.MONTH));
+        assertEquals(3, valueDate.get(Calendar.DAY_OF_MONTH));
+
+        assertNull(strategy.tradeDate(mt).orElse(null));
+
+        assertEquals("AGBLLT2XXXX", strategy.sender(mt).orElse(null));
+        assertEquals("TESTARZZXXX", strategy.receiver(mt).orElse(null));
+
+        assertEquals("fin.103", strategy.identifier(mt).orElse(null));
+    }
+
+    @Test
+    public void testParseAck() throws IOException {
+        AbstractMT mt = AbstractMT.parse("{1:F21AAAALT2XAXXX0000000000}{4:{177:1903250612}{451:0}{108:MYMUR123458}}");
+
+        DefaultMtMetadataStrategy strategy = new DefaultMtMetadataStrategy();
+
+        assertEquals("MYMUR123458", strategy.reference(mt).orElse(null));
+        assertNull(strategy.amount(mt).orElse(null));
+        assertNull(strategy.valueDate(mt).orElse(null));
+        assertNull(strategy.tradeDate(mt).orElse(null));
+
+        // the receiver and sender are swapped in the ACK because the ACK is sent by the SWIFT interface back to the
+        // sender of the original message. From the ACK perspective, the original sender is the receiver of the ACK.
+        assertEquals("AAAALT2XXXX", strategy.receiver(mt).orElse(null));
+
+        // the ACK itself (service 21) does not have a sender (it is sent by the SWIFT interface)
+        assertNull(strategy.sender(mt).orElse(null));
+
+        assertEquals("ACK", strategy.identifier(mt).orElse(null));
+    }
+
+    @Test
+    public void testParseNak() throws IOException {
+        AbstractMT mt = AbstractMT.parse("{1:F21AAAALT2XAXXX0000000000}{4:{177:1903250612}{451:1}{108:MYMUR123458}}");
+
+        DefaultMtMetadataStrategy strategy = new DefaultMtMetadataStrategy();
+
+        assertEquals("MYMUR123458", strategy.reference(mt).orElse(null));
+        assertNull(strategy.amount(mt).orElse(null));
+        assertNull(strategy.valueDate(mt).orElse(null));
+        assertNull(strategy.tradeDate(mt).orElse(null));
+
+        // the receiver and sender are swapped in the ACK because the ACK is sent by the SWIFT interface back to the
+        // sender of the original message. From the ACK perspective, the original sender is the receiver of the ACK.
+        assertEquals("AAAALT2XXXX", strategy.receiver(mt).orElse(null));
+
+        // the ACK itself (service 21) does not have a sender (it is sent by the SWIFT interface)
+        assertNull(strategy.sender(mt).orElse(null));
+
+        assertEquals("NAK", strategy.identifier(mt).orElse(null));
+    }
+
+    @Test
+    public void testParseAckWithOriginalMessageCopy() throws IOException {
+        AbstractMT mt = AbstractMT.parse(
+                "{1:F21AAAALT2XAXXX0000000000}{4:{177:1903250612}{451:0}}{1:F01AAAALT2XAXXX1012000002}{2:I103BBBBARZZXXXXN}{4:\n"
+                        + ":20:TEST\n"
+                        + ":32A:090903USD23453,"
+                        + "-}");
+
+        DefaultMtMetadataStrategy strategy = new DefaultMtMetadataStrategy();
+
+        assertEquals("TEST", strategy.reference(mt).orElse(null));
+
+        // the original message is included in the ACK, we can extract the amount from it
+        Money money = strategy.amount(mt).orElse(null);
+        assertNotNull(money);
+        assertEquals("USD", money.getCurrency());
+        assertEquals(new BigDecimal("23453"), money.getAmount());
+
+        // the original message is included in the ACK, we can extract the value date from it
+        Calendar valueDate = strategy.valueDate(mt).orElse(null);
+        assertNotNull(valueDate);
+        assertEquals(2009, valueDate.get(Calendar.YEAR));
+        assertEquals(Calendar.SEPTEMBER, valueDate.get(Calendar.MONTH));
+        assertEquals(3, valueDate.get(Calendar.DAY_OF_MONTH));
+
+        assertNull(strategy.tradeDate(mt).orElse(null));
+
+        // the receiver and sender are swapped in the ACK because the ACK is sent by the SWIFT interface back to the
+        // sender of the original message. From the ACK perspective, the original sender is the receiver of the ACK.
+        assertEquals("AAAALT2XXXX", strategy.receiver(mt).orElse(null));
+
+        // the ACK itself (service 21) does not have a sender (it is sent by the SWIFT interface) however for conveniece
+        // we extract as sender the counterparty BIC in the origina message
+        assertEquals("BBBBARZZXXX", strategy.sender(mt).orElse(null));
+
+        assertEquals("ACK", strategy.identifier(mt).orElse(null));
+    }
+}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Enhanced support for SWIFT ACK/NAK (service 21) messages, including improved extraction of sender, receiver, reference, value date, and amount from both ACK/NAK and embedded original messages.

- **Bug Fixes**
  - Corrected extraction of receiver information for ACK/NAK messages to ensure the BIC is set appropriately.

- **Documentation**
  - Updated documentation to clarify metadata extraction behavior for ACK/NAK messages and BIC11 formatting.

- **Tests**
  - Added and extended test coverage for ACK/NAK message scenarios, ensuring accurate metadata extraction and improved reliability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->