### PR TITLE
(CU-86b56qtwv) Fix NPE when create invalid BIC

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Prowide Core - CHANGELOG
 
+#### 10.2.8 - SNAPSHOT
+  * Fix: Enhanced the `DefaultMtMetadataStrategy` to prevent NPE when the message headers are malformed
+
 #### 10.2.7 - May 2025
   * (PW-2055) Fixed the default message metadata extraction for ACK/NAK to set the service message block 1 BIC as receiver, not as sender
   * (PW-2055) Enhanced the `SwiftMessageUtils` extractors to support the service 21 message type (ACK/NAK)

--- a/src/main/java/com/prowidesoftware/swift/model/mt/DefaultMtMetadataStrategy.java
+++ b/src/main/java/com/prowidesoftware/swift/model/mt/DefaultMtMetadataStrategy.java
@@ -31,6 +31,9 @@ import java.util.Optional;
  */
 public class DefaultMtMetadataStrategy implements MessageMetadataStrategy {
 
+    private static final java.util.logging.Logger log =
+            java.util.logging.Logger.getLogger(DefaultMtMetadataStrategy.class.getName());
+
     /**
      * Extracts the MT main reference using {@link SwiftMessageUtils#reference(SwiftMessage)}
      */
@@ -71,7 +74,11 @@ public class DefaultMtMetadataStrategy implements MessageMetadataStrategy {
     public Optional<String> sender(AbstractMessage message) {
         final String sender = SwiftMessageUtils.sender(asSwiftMessage(message));
         if (sender != null) {
-            return Optional.of(new BIC(sender).getBic11());
+            if (new BIC(sender).isValid()) {
+                return Optional.of(new BIC(sender).getBic11());
+            } else {
+                log.fine("Invalid BIC: " + sender);
+            }
         }
         return Optional.empty();
     }
@@ -84,7 +91,11 @@ public class DefaultMtMetadataStrategy implements MessageMetadataStrategy {
     public Optional<String> receiver(AbstractMessage message) {
         final String receiver = SwiftMessageUtils.receiver(asSwiftMessage(message));
         if (receiver != null) {
-            return Optional.of(new BIC(receiver).getBic11());
+            if (new BIC(receiver).isValid()) {
+                return Optional.of(new BIC(receiver).getBic11());
+            } else {
+                log.fine("Invalid BIC: " + receiver);
+            }
         }
         return Optional.empty();
     }

--- a/src/main/java/com/prowidesoftware/swift/model/mt/DefaultMtMetadataStrategy.java
+++ b/src/main/java/com/prowidesoftware/swift/model/mt/DefaultMtMetadataStrategy.java
@@ -74,8 +74,9 @@ public class DefaultMtMetadataStrategy implements MessageMetadataStrategy {
     public Optional<String> sender(AbstractMessage message) {
         final String sender = SwiftMessageUtils.sender(asSwiftMessage(message));
         if (sender != null) {
-            if (new BIC(sender).isValid()) {
-                return Optional.of(new BIC(sender).getBic11());
+            BIC bic = new BIC(sender);
+            if (bic.isValid()) {
+                return Optional.of(bic.getBic11());
             } else {
                 log.fine("Invalid BIC: " + sender);
             }
@@ -91,8 +92,9 @@ public class DefaultMtMetadataStrategy implements MessageMetadataStrategy {
     public Optional<String> receiver(AbstractMessage message) {
         final String receiver = SwiftMessageUtils.receiver(asSwiftMessage(message));
         if (receiver != null) {
-            if (new BIC(receiver).isValid()) {
-                return Optional.of(new BIC(receiver).getBic11());
+            BIC bic = new BIC(receiver);
+            if (bic.isValid()) {
+                return Optional.of(bic.getBic11());
             } else {
                 log.fine("Invalid BIC: " + receiver);
             }

--- a/src/main/java/com/prowidesoftware/swift/model/mt/DefaultMtMetadataStrategy.java
+++ b/src/main/java/com/prowidesoftware/swift/model/mt/DefaultMtMetadataStrategy.java
@@ -73,15 +73,7 @@ public class DefaultMtMetadataStrategy implements MessageMetadataStrategy {
     @Override
     public Optional<String> sender(AbstractMessage message) {
         final String sender = SwiftMessageUtils.sender(asSwiftMessage(message));
-        if (sender != null) {
-            BIC bic = new BIC(sender);
-            if (bic.isValid()) {
-                return Optional.of(bic.getBic11());
-            } else {
-                log.fine("Invalid BIC: " + sender);
-            }
-        }
-        return Optional.empty();
+        return getBIC(sender);
     }
 
     /**
@@ -91,12 +83,16 @@ public class DefaultMtMetadataStrategy implements MessageMetadataStrategy {
     @Override
     public Optional<String> receiver(AbstractMessage message) {
         final String receiver = SwiftMessageUtils.receiver(asSwiftMessage(message));
-        if (receiver != null) {
-            BIC bic = new BIC(receiver);
+        return getBIC(receiver);
+    }
+
+    private static Optional<String> getBIC(String inputBIC) {
+        if (inputBIC != null) {
+            BIC bic = new BIC(inputBIC);
             if (bic.isValid()) {
                 return Optional.of(bic.getBic11());
             } else {
-                log.fine("Invalid BIC: " + receiver);
+                log.fine("Invalid BIC: " + inputBIC);
             }
         }
         return Optional.empty();

--- a/src/main/java/com/prowidesoftware/swift/model/mt/DefaultMtMetadataStrategy.java
+++ b/src/main/java/com/prowidesoftware/swift/model/mt/DefaultMtMetadataStrategy.java
@@ -94,7 +94,7 @@ public class DefaultMtMetadataStrategy implements MessageMetadataStrategy {
     private static Optional<String> getBIC(String inputBIC) {
         if (inputBIC != null) {
             BIC bic = new BIC(inputBIC);
-            if (bic.isValid()) {
+            if (bic.getBic11() != null) {
                 return Optional.of(bic.getBic11());
             } else {
                 log.fine("Invalid BIC: " + inputBIC);

--- a/src/main/java/com/prowidesoftware/swift/model/mt/DefaultMtMetadataStrategy.java
+++ b/src/main/java/com/prowidesoftware/swift/model/mt/DefaultMtMetadataStrategy.java
@@ -86,6 +86,11 @@ public class DefaultMtMetadataStrategy implements MessageMetadataStrategy {
         return getBIC(receiver);
     }
 
+    /**
+     *
+     * @param inputBIC the BIC to validate and convert to BIC11 format
+     * @return the BIC11 format of the input BIC, if valid, or an empty Optional if the input is null or invalid.
+     */
     private static Optional<String> getBIC(String inputBIC) {
         if (inputBIC != null) {
             BIC bic = new BIC(inputBIC);

--- a/src/test/java/com/prowidesoftware/swift/model/BICTest.java
+++ b/src/test/java/com/prowidesoftware/swift/model/BICTest.java
@@ -170,4 +170,15 @@ public class BICTest {
         assertEquals("BACOARB0XXX", new BIC("BACOARB1XXX").asTestBic().getBic11());
         assertEquals("BACOARB00BE", new BIC("BACOARB10BE").asTestBic().getBic11());
     }
+
+    @Test
+    public void testInvalidSender() {
+        final String finO = "{1:F01AAAACAT3BIMM0018055280}{2:O199BBBBCATTXXXXN}{3:{108:REFFORMURTEST123}}{4:\n"
+                + ":20:REF987654FFF\n"
+                + ":79:FOOBARMURTEST\n"
+                + "-}";
+        // Parse the message and avoid NPE check in the Sender BIC
+        MtSwiftMessage mt2 = MtSwiftMessage.parse(finO);
+        System.out.println(mt2);
+    }
 }

--- a/src/test/java/com/prowidesoftware/swift/model/BICTest.java
+++ b/src/test/java/com/prowidesoftware/swift/model/BICTest.java
@@ -170,30 +170,4 @@ public class BICTest {
         assertEquals("BACOARB0XXX", new BIC("BACOARB1XXX").asTestBic().getBic11());
         assertEquals("BACOARB00BE", new BIC("BACOARB10BE").asTestBic().getBic11());
     }
-
-    @Test
-    public void testInvalidSender() {
-        final String finO = "{1:F01AAAACAT3BIMM0018055280}{2:O199BBBBCATTXXXXN}{3:{108:REFFORMURTEST123}}{4:\n"
-                + ":20:REF987654FFF\n"
-                + ":79:FOOBARMURTEST\n"
-                + "-}";
-
-        // Parse the message and avoid NPE check in the Sender BIC
-        MtSwiftMessage mt2 = MtSwiftMessage.parse(finO);
-        assertNull(mt2.getSender());
-        assertNotNull(mt2.getReceiver());
-    }
-
-    @Test
-    public void testInvalidReceiver() {
-        final String finO = "{1:F01AAAACAT3BIMM0018055280}{2:I199BBBBCATTXXXXN}{3:{108:REFFORMURTEST123}}{4:\n"
-                + ":20:REF987654FFF\n"
-                + ":79:FOOBARMURTEST\n"
-                + "-}";
-
-        // Parse the message and avoid NPE check in the Sender BIC
-        MtSwiftMessage mt2 = MtSwiftMessage.parse(finO);
-        assertEquals("AAAACAT3IMM", mt2.getSender());
-        assertEquals("BBBBCATTXXX", mt2.getReceiver());
-    }
 }

--- a/src/test/java/com/prowidesoftware/swift/model/BICTest.java
+++ b/src/test/java/com/prowidesoftware/swift/model/BICTest.java
@@ -181,5 +181,19 @@ public class BICTest {
         // Parse the message and avoid NPE check in the Sender BIC
         MtSwiftMessage mt2 = MtSwiftMessage.parse(finO);
         assertNull(mt2.getSender());
+        assertNotNull(mt2.getReceiver());
+    }
+
+    @Test
+    public void testInvalidReceiver() {
+        final String finO = "{1:F01AAAACAT3BIMM0018055280}{2:I199BBBBCATTXXXXN}{3:{108:REFFORMURTEST123}}{4:\n"
+                + ":20:REF987654FFF\n"
+                + ":79:FOOBARMURTEST\n"
+                + "-}";
+
+        // Parse the message and avoid NPE check in the Sender BIC
+        MtSwiftMessage mt2 = MtSwiftMessage.parse(finO);
+        assertEquals("AAAACAT3IMM", mt2.getSender());
+        assertEquals("BBBBCATTXXX", mt2.getReceiver());
     }
 }

--- a/src/test/java/com/prowidesoftware/swift/model/BICTest.java
+++ b/src/test/java/com/prowidesoftware/swift/model/BICTest.java
@@ -177,8 +177,9 @@ public class BICTest {
                 + ":20:REF987654FFF\n"
                 + ":79:FOOBARMURTEST\n"
                 + "-}";
+
         // Parse the message and avoid NPE check in the Sender BIC
         MtSwiftMessage mt2 = MtSwiftMessage.parse(finO);
-        System.out.println(mt2);
+        assertNull(mt2.getSender());
     }
 }

--- a/src/test/java/com/prowidesoftware/swift/model/mt/DefaultMtMetadataStrategyTest.java
+++ b/src/test/java/com/prowidesoftware/swift/model/mt/DefaultMtMetadataStrategyTest.java
@@ -3,6 +3,7 @@ package com.prowidesoftware.swift.model.mt;
 import static org.junit.jupiter.api.Assertions.*;
 
 import com.prowidesoftware.swift.model.Money;
+import com.prowidesoftware.swift.model.MtSwiftMessage;
 import java.io.IOException;
 import java.math.BigDecimal;
 import java.util.Calendar;
@@ -118,5 +119,68 @@ class DefaultMtMetadataStrategyTest {
         assertEquals("BBBBARZZXXX", strategy.sender(mt).orElse(null));
 
         assertEquals("ACK", strategy.identifier(mt).orElse(null));
+    }
+
+    @Test
+    public void testInvalidSenderInputMessage() {
+        MtSwiftMessage mt = MtSwiftMessage.parse(
+                "{1:F01AAAAAAAAAAAA1234567890}{2:I199CHASUS33XXXXN}{4:\n" + ":20:REF987654FFF\n" + "-}");
+
+        assertNotNull(mt.getReceiver());
+        assertEquals("CHASUS33XXX", mt.getReceiver());
+
+        assertNotNull(mt.getSender());
+        assertEquals("AAAAAAAAAAA", mt.getSender());
+    }
+
+    @Test
+    public void testInvalidReceiverInputMessage() {
+        MtSwiftMessage mt = MtSwiftMessage.parse(
+                "{1:F01CHASUS33AXXX1234567890}{2:I199AAAAAAAAAAAAN}{4:\n" + ":20:REF987654FFF\n" + "-}");
+
+        assertNotNull(mt.getSender());
+        assertEquals("CHASUS33XXX", mt.getSender());
+
+        assertNotNull(mt.getReceiver());
+        assertEquals("AAAAAAAAAAA", mt.getReceiver());
+    }
+
+    @Test
+    public void testInvalidSenderOutputMessage() {
+        MtSwiftMessage mt = MtSwiftMessage.parse(
+                "{1:F01CHASUS33XXXX1234567890}{2:O1990811060227AAAAAAAAAAAA55529746000602270811N}{4:\n"
+                        + ":20:REF987654FFF\n" + "-}");
+
+        assertNotNull(mt.getSender());
+        assertEquals("AAAAAAAAAAA", mt.getSender());
+
+        assertNotNull(mt.getReceiver());
+        assertEquals("CHASUS33XXX", mt.getReceiver());
+    }
+
+    @Test
+    public void testInvalidReceiverOutputMessage() {
+        MtSwiftMessage mt = MtSwiftMessage.parse(
+                "{1:F01CHASUS33AXXX1234567890}{2:O1990811060227AAAAAAAAAAAA55529746000602270811N}{4:\n"
+                        + ":20:REF987654FFF\n" + "-}");
+
+        assertNotNull(mt.getReceiver());
+        assertEquals("CHASUS33XXX", mt.getReceiver());
+
+        assertNotNull(mt.getSender());
+        assertEquals("AAAAAAAAAAA", mt.getSender());
+    }
+
+    @Test
+    public void testMalformedBlock2() {
+        // block 2 has the structure of an Input block, but the block direction is set to "O" for Output
+        MtSwiftMessage mt = MtSwiftMessage.parse(
+                "{1:F01CHASUS33AXXX1234567890}{2:O199AAAAAAAAAAAAN}{4:\n" + ":20:REF987654FFF\n" + "-}");
+
+        assertNotNull(mt.getReceiver());
+        assertEquals("CHASUS33XXX", mt.getReceiver());
+
+        // sender BIC cannot be parsed from the malformed block 2
+        assertNull(mt.getSender());
     }
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved handling of malformed SWIFT message headers to prevent errors when sender or receiver information is invalid or missing.

- **Tests**
  - Added new tests to ensure correct extraction and validation of sender and receiver BIC codes from messages with malformed or incomplete headers.

- **Documentation**
  - Updated changelog with details of the latest fix.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->