### PR TITLE
(PW-2631) Sender-LT-X->A fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 #### 10.2.13 - SNAPSHOT
   * feat: Enhanced SwiftParser for edge cases avoiding OutOfBoundsException when parsing messages with empty blocks
+  * LogicalTerminalAddress: Sender LT X is allowed for load balancing by Messaging Interface. 
 
 #### 10.2.12 - July 2025
   * (PW-2613) Updated the Field70 codeword splitting logic to allow / as trailing chars

--- a/src/main/java/com/prowidesoftware/swift/model/LogicalTerminalAddress.java
+++ b/src/main/java/com/prowidesoftware/swift/model/LogicalTerminalAddress.java
@@ -20,12 +20,16 @@ import org.apache.commons.lang3.StringUtils;
 
 /**
  * Identifies a logical channel connection to SWIFT, and the network uses it for addressing.
- * It is basically a BIC code with an additional character identifier the terminal sending the message. The LT
- * identifier is located in position 9 of a full 12 characters address.
+ * It is basically a BIC code with an additional character identifier the terminal sending the message.
+ * The LT identifier is located in position 9 of a full 12 characters address.
  * For example letter 'A' in CCCCUS33AXXX<br>
  * <p>
- * A sender LT address cannot have 'X' as LT identifier, conversely a
- * receiver LT address must have an 'X' as LT identifier.
+ * A sender LT address cannot have 'X' as LT identifier as it is a reserved character for LT.
+ * SWIFT NAK the messages with H10 error when messages sent to their network.
+ * However, messages to Messaging Interface can have 'X' as LT Identifier
+ * that will be used as wild card to load balance the LT and replaced by
+ * Messaging Interface before sending to SWIFT to the corresponding LT Value.
+ * A receiver LT address must have an 'X' as LT identifier.
  *
  * @author sebastian
  * @since 7.6
@@ -76,14 +80,14 @@ public class LogicalTerminalAddress extends BIC {
      * the returned code has 12 characters and with no "X" in the 9th position.
      *
      * <p>If the terminal identifier is not set or if it is set to "X", then
-     * the default identifier "A" will be used.
+     * the wildcard LT identifier "X" will be used.
      *
      * <p>The branch code is padded with "XXX" if not present.
      *
      * @return the 12 characters address or null if the BIC has less than 8 characters
      */
     public String getSenderLogicalTerminalAddress() {
-        char LT = this.lTIdentifier == null || this.lTIdentifier.equals('X') ? 'A' : this.lTIdentifier;
+        char LT = this.lTIdentifier == null ? 'X' : this.lTIdentifier;
         if (getBic8() != null) {
             return getBic8() + LT + getBranchOrDefault();
         }

--- a/src/test/java/com/prowidesoftware/swift/model/LogicalTerminalAddressTest.java
+++ b/src/test/java/com/prowidesoftware/swift/model/LogicalTerminalAddressTest.java
@@ -118,9 +118,9 @@ public class LogicalTerminalAddressTest {
     @Test
     public void testSenderLT() {
         assertEquals("FOOOOOHUAXXX", new LogicalTerminalAddress("FOOOOOHUAXXX").getSenderLogicalTerminalAddress());
-        assertEquals("FOOOOOHUAXXX", new LogicalTerminalAddress("FOOOOOHUXXXX").getSenderLogicalTerminalAddress());
-        assertEquals("FOOOOOHUAXXX", new LogicalTerminalAddress("FOOOOOHUXXX").getSenderLogicalTerminalAddress());
-        assertEquals("FOOOOOHUAXXX", new LogicalTerminalAddress("FOOOOOHU").getSenderLogicalTerminalAddress());
+        assertEquals("FOOOOOHUXXXX", new LogicalTerminalAddress("FOOOOOHUXXXX").getSenderLogicalTerminalAddress());
+        assertEquals("FOOOOOHUXXXX", new LogicalTerminalAddress("FOOOOOHUXXX").getSenderLogicalTerminalAddress());
+        assertEquals("FOOOOOHUXXXX", new LogicalTerminalAddress("FOOOOOHU").getSenderLogicalTerminalAddress());
         assertNull(new LogicalTerminalAddress("FOO").getSenderLogicalTerminalAddress());
     }
 


### PR DESCRIPTION
Fixing the LT X -> A default replacement in the Sender Logical Terminal Address.