### PR TITLE
(CU-86b8v3uxa) Fix metadata extraction for ACK followed by MT Output

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Prowide Core - CHANGELOG
 
+### 10.3.11 - SNAPSHOT
+  * Fix: `MtSwiftMessage` created from ACK (service 21) followed by MT with block 2 Output now extracts the message type and metadata from the appended MT instead of defaulting to ACK
+
 #### 10.3.10 - March 2026
   * Migrated deprecated `StringUtils` methods to `Strings.CS` equivalents (equals, startsWith, endsWith, contains, replace, indexOf, lastIndexOf, remove, removeEnd)
   * (PW-3126) Fixed DN to BIC extraction in `DistinguishedName` to include the branch code from the `ou` component

--- a/src/main/java/com/prowidesoftware/swift/model/MtSwiftMessage.java
+++ b/src/main/java/com/prowidesoftware/swift/model/MtSwiftMessage.java
@@ -81,8 +81,9 @@ public class MtSwiftMessage extends AbstractSwiftMessage {
      * content will be stored in the message attribute but the metadata (such as the message type) will be extracted
      * from the first message only.
      *
-     * <p>Notice that if an ACK/NAK message is used as parameter, this object will represent the ACK/NAK.
-     * Even if the original message is attached after the service 21 messages.
+     * <p>If an ACK/NAK (service 21) message is used as parameter and includes an appended MT with block 2 Output,
+     * the metadata is extracted from the appended MT. For ACK/NAK with an appended MT with block 2 Input or without
+     * an appended MT, the message is represented as ACK/NAK.
      *
      * <p>File format is set to {@link FileFormat#FIN}
      *
@@ -268,25 +269,46 @@ public class MtSwiftMessage extends AbstractSwiftMessage {
      * This method extracts the metadata from the model and sets the internal attributes accordingly, using the
      * provided {@link MessageMetadataStrategy}. And on top of that, sets additional attributes such as the
      * last modified date, checksum, and MUR.
-     *
+     * <p>
+     * For ACK/NAK (service 21) messages with an appended MT that has block 2 Output, the metadata is extracted
+     * from the appended MT rather than from the ACK/NAK prefix.
      *
      * @param model            the SwiftMessage model to extract metadata from
      * @param metadataStrategy a strategy implementation to extract the metadata from the model
      */
     private void updateAttributes(final SwiftMessage model, final MessageMetadataStrategy metadataStrategy) {
-        applyStrategy(model, metadataStrategy);
+        // for ACK/NAK with an appended MT Output, use the appended MT as the effective model for metadata extraction
+        final SwiftMessage effectiveModel = resolveEffectiveModel(model);
+
+        applyStrategy(effectiveModel, metadataStrategy);
 
         setFileFormat(FileFormat.FIN);
         setLastModified(Calendar.getInstance());
-        setMur(model.getMUR());
-        setPde(model.getPDE());
-        setPdm(model.getPDM());
-        setMir(model.getMIR());
-        if (model.getBlock2() != null) {
-            setUuid(model.getUUID());
+        setMur(effectiveModel.getMUR());
+        setPde(effectiveModel.getPDE());
+        setPdm(effectiveModel.getPDM());
+        setMir(effectiveModel.getMIR());
+        if (effectiveModel.getBlock2() != null) {
+            setUuid(effectiveModel.getUUID());
         }
-        setDirection(model.getDirection());
-        setUetr(model.getUETR());
+        setDirection(effectiveModel.getDirection());
+        setUetr(effectiveModel.getUETR());
+    }
+
+    /**
+     * For ACK/NAK (service 21) messages with an appended MT that has block 2 Output, returns the appended MT model.
+     * Otherwise, returns the original model unchanged.
+     */
+    private SwiftMessage resolveEffectiveModel(final SwiftMessage model) {
+        if (model.isServiceMessage21() && model.getUnparsedTextsSize() > 0) {
+            final SwiftMessage original = model.getUnparsedTexts().getTextAsMessage(0);
+            if (original != null
+                    && original.getBlock2() != null
+                    && original.getBlock2().isOutput()) {
+                return original;
+            }
+        }
+        return model;
     }
 
     /**

--- a/src/main/java/com/prowidesoftware/swift/model/SwiftMessageUtils.java
+++ b/src/main/java/com/prowidesoftware/swift/model/SwiftMessageUtils.java
@@ -357,7 +357,9 @@ public class SwiftMessageUtils {
      * Get a string in the form of businessprocess.messagetype.variant
      *
      * <p>
-     * For acknowledges and negative acknowledges, the identifier is fixed to "ACK" and "NAK" respectively.
+     * For acknowledges and negative acknowledges with an appended MT with block 2 Input, the identifier is fixed
+     * to "ACK" and "NAK" respectively. However, if the appended MT has block 2 Output, the identifier is extracted
+     * from the appended MT message type.
      *
      * @return a string with the MT message type identification
      * @since 9.3.19
@@ -366,8 +368,16 @@ public class SwiftMessageUtils {
         if (m == null) {
             return null;
         }
-        // for ACK/NAK messages, we return the fixed identifiers
+        // for ACK/NAK messages with an appended MT with block 2 Output, we extract the identifier from the MT
         if (m.isServiceMessage21()) {
+            if (m.getUnparsedTextsSize() > 0) {
+                final SwiftMessage original = m.getUnparsedTexts().getTextAsMessage(0);
+                if (original != null
+                        && original.getBlock2() != null
+                        && original.getBlock2().isOutput()) {
+                    return identifier(original);
+                }
+            }
             if (m.isAck()) {
                 return MtSwiftMessage.IDENTIFIER_ACK;
             } else if (m.isNack()) {

--- a/src/test/java/com/prowidesoftware/swift/model/MtSwiftMessageTest.java
+++ b/src/test/java/com/prowidesoftware/swift/model/MtSwiftMessageTest.java
@@ -70,7 +70,8 @@ public class MtSwiftMessageTest {
     }
 
     @Test
-    public void testParseAckWithOriginalMessageCopy() {
+    public void testParseAckWithOriginalMessageCopyInput() {
+        // ACK followed by MT with block 2 Input -> identifier should be ACK
         String fin =
                 "{1:F21AAAALT2XAXXX0000000000}{4:{177:1903250612}{451:0}}{1:F01AAAALT2XAXXX1012000002}{2:I103BBBBARZZXXXXN}{4:\n"
                         + ":20:TEST\n"
@@ -101,6 +102,40 @@ public class MtSwiftMessageTest {
         // the original message has an amount, we extract it
         assertEquals(new BigDecimal("23453"), mt.getAmount());
         assertEquals("USD", mt.getCurrency());
+
+        // ACK followed by MT Input keeps the ACK identifier
+        assertEquals("ACK", mt.getIdentifier());
+    }
+
+    @Test
+    public void testParseAckWithOriginalMessageCopyOutput() {
+        // ACK followed by MT with block 2 Output -> metadata should be extracted from the appended MT
+        String fin =
+                "{1:F21AAAALT2XAXXX0000000000}{4:{177:1903250612}{451:0}}{1:F01BBBBARZZAXXX1012000002}{2:O1031200190903AAAALT2XAXXX00000000001903250612N}{3:{121:d]8b27e4-5891-4649-b1b8-22a3c0985ab2}}{4:\n"
+                        + ":20:TEST-OUT\n"
+                        + ":32A:190903EUR12345,\n"
+                        + "-}";
+        MtSwiftMessage mt = MtSwiftMessage.parse(fin);
+
+        // identifier and message type are extracted from the appended MT, not "ACK"
+        assertEquals("fin.103", mt.getIdentifier());
+        assertEquals("103", mt.getMessageType());
+
+        // reference is extracted from the appended MT
+        assertEquals("TEST-OUT", mt.getReference());
+
+        // direction is resolved from the appended MT's block 2 Output (incoming)
+        assertEquals(MessageIOType.incoming, mt.getDirection());
+
+        // value date from the appended MT
+        Calendar valueDate = mt.getValueDate();
+        assertEquals(2019, valueDate.get(Calendar.YEAR));
+        assertEquals(Calendar.SEPTEMBER, valueDate.get(Calendar.MONTH));
+        assertEquals(3, valueDate.get(Calendar.DAY_OF_MONTH));
+
+        // amount from the appended MT
+        assertEquals(new BigDecimal("12345"), mt.getAmount());
+        assertEquals("EUR", mt.getCurrency());
     }
 
     @Test


### PR DESCRIPTION
## Summary
- ACK (service 21) followed by MT with block 2 Output now extracts all metadata (identifier, direction, MIR, UUID, UETR, etc.) from the appended MT instead of defaulting to ACK
- ACK followed by MT with block 2 Input preserves the existing ACK/NAK behavior
- Changes in `MtSwiftMessage.updateAttributes()` (via `resolveEffectiveModel()`) and `SwiftMessageUtils.identifier()`

## Test plan
- [x] Existing test `testParseAckWithOriginalMessageCopyInput` verifies ACK + MT Input keeps identifier as "ACK"
- [x] New test `testParseAckWithOriginalMessageCopyOutput` verifies ACK + MT Output extracts identifier, direction, value date, and amount from the appended MT
- [x] All existing tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)