### PR TITLE
Improve the performance of SwiftParseUtils.getLines(...)

### DIFF
--- a/src/main/java/com/prowidesoftware/swift/model/field/SwiftParseUtils.java
+++ b/src/main/java/com/prowidesoftware/swift/model/field/SwiftParseUtils.java
@@ -15,10 +15,6 @@
  */
 package com.prowidesoftware.swift.model.field;
 
-import com.prowidesoftware.ProwideException;
-import java.io.BufferedReader;
-import java.io.IOException;
-import java.io.StringReader;
 import java.util.ArrayList;
 import java.util.List;
 import org.apache.commons.lang3.StringUtils;
@@ -382,23 +378,24 @@ public class SwiftParseUtils {
 
     /**
      * Separate the given string in lines, removing trailing empty lines.
-     * <p>The implementation uses using {@link BufferedReader#readLine()} so if the string ends with a LF, the trailing
-     * "empty" line is not returned in the result.
      *
      * @return list of found lines
      */
     public static List<String> getLines(final String value) {
         final List<String> result = new ArrayList<>();
         if (value != null) {
-            final BufferedReader br = new BufferedReader(new StringReader(value));
-            try {
-                String l = br.readLine();
-                while (l != null) {
-                    result.add(l);
-                    l = br.readLine();
+            int offset = 0;
+            int index;
+            while ((index = value.indexOf('\n', offset)) != -1) {
+                if (index > 0 && value.charAt(index - 1) == '\r') {
+                    result.add(value.substring(offset, index - 1));
+                } else {
+                    result.add(value.substring(offset, index));
                 }
-            } catch (final IOException e) {
-                throw new ProwideException(e);
+                offset = index + 1;
+            }
+            if (offset < value.length()) {
+                result.add(value.substring(offset));
             }
         }
         return result;

--- a/src/test/java/com/prowidesoftware/swift/model/field/SwiftParseUtilsTest.java
+++ b/src/test/java/com/prowidesoftware/swift/model/field/SwiftParseUtilsTest.java
@@ -17,6 +17,7 @@ package com.prowidesoftware.swift.model.field;
 
 import static org.junit.jupiter.api.Assertions.*;
 
+import java.util.List;
 import org.junit.jupiter.api.Test;
 
 public class SwiftParseUtilsTest {
@@ -332,5 +333,20 @@ public class SwiftParseUtilsTest {
         assertEquals("aaa", SwiftParseUtils.removePrefix("aaa", "/"));
         assertEquals("aaa", SwiftParseUtils.removePrefix("/aaa", "/"));
         assertEquals("/aaa", SwiftParseUtils.removePrefix("//aaa", "/"));
+    }
+
+    @Test
+    public void testGetLines() {
+        List<String> lines = SwiftParseUtils.getLines("Line 1\nLine 2\r\nLine 3\n\rLine 4");
+        assertEquals(4, lines.size());
+        assertEquals("Line 1", lines.get(0));
+        assertEquals("Line 2", lines.get(1));
+        assertEquals("Line 3", lines.get(2));
+        assertEquals("\rLine 4", lines.get(3));
+
+        lines = SwiftParseUtils.getLines("Line 1\nLine 2\n");
+        assertEquals(2, lines.size());
+        assertEquals("Line 1", lines.get(0));
+        assertEquals("Line 2", lines.get(1));
     }
 }


### PR DESCRIPTION
Reimplements `SwiftParseUtils.getLines(...)` without using `StringReader` and `BufferedReader`, this function is currently a hotspot in our high performance scenarios and reimplementing like this eliminates the hotspot. (A new `BufferedReader` each time is quite heavy for a lot of fields in an input file.)