### PR TITLE
Fix getFieldsByNumber throwing on unknown letter option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Prowide Core - CHANGELOG
 
 ### 10.3.14 - May 2026
+  * Fix: `SwiftTagListBlock.getFieldsByNumber(int)` no longer throws `IllegalArgumentException` when a matching tag cannot be converted into a `Field` (for example a newer letter option such as `20U` not known to the running library version); such tags are now logged and skipped, consistently with the name-based lookups. This also fixes `SwiftMessageUtils.reference()` failing on category-5 messages that contain an unrecognized `20`-numbered sibling tag
   * Fix: Fields definitions alignment: `Field30I` and `Field30K` component 2 made optional (and `Field30K` validation pattern updated to `<DATE4>[/<DATE4>]`), `Field39M` validation pattern updated to `<CC>`, and `Field56B` name & address component made optional
   * Fix: Minor changes in MT message structures from SRU2025 schema: MT306, MT340, MT500-MT502, MT504, MT508, MT510, MT513-MT515, MT518, MT519, MT524, MT527, MT530, MT535-MT538, MT540-MT548, MT558, MT564-MT566, MT575, MT578, MT586, MT600, MT601, MT671
 

--- a/src/main/java/com/prowidesoftware/swift/model/SwiftTagListBlock.java
+++ b/src/main/java/com/prowidesoftware/swift/model/SwiftTagListBlock.java
@@ -480,6 +480,9 @@ public class SwiftTagListBlock extends SwiftBlock implements Serializable, Itera
      * Get all Fields of a given number.<br>
      * For example: for 59 will return any of 59, 59A, 59F, etc...
      *
+     * <p>Tags that match the number but cannot be converted into a {@link Field} (for example a newer letter option
+     * not known to the current library version) are logged and skipped, consistently with {@link #getFieldsByName(String, String)}.
+     *
      * @param fieldNumber the field number to search
      * @return the fields matching the given number or an empty list if none is found.
      * @see #getTagsByNumber(int)
@@ -489,7 +492,7 @@ public class SwiftTagListBlock extends SwiftBlock implements Serializable, Itera
         for (Tag tag : getTagsByNumber(fieldNumber)) {
             final Field f = tag.asField();
             if (f == null) {
-                throw new IllegalArgumentException("Unable to create field for tagname " + tag.getName());
+                log.warning("Could not create field instance of " + tag);
             } else {
                 result.add(f);
             }
@@ -500,6 +503,10 @@ public class SwiftTagListBlock extends SwiftBlock implements Serializable, Itera
     /**
      * Gets the first field matching the given number and component value.
      * For example: for 59 will return any of 59, 59A, 59F, etc...
+     *
+     * <p>Tags that share the requested number but cannot be converted into a {@link Field} (for example a newer
+     * letter option not known to the current library version) are skipped, so a single unknown sibling
+     * tag does not prevent matching a known one.
      *
      * @param fieldNumber    the field number to search
      * @param componentValue expected value for component 1 in the matched field

--- a/src/test/java/com/prowidesoftware/swift/model/SwiftTagListBlockTest.java
+++ b/src/test/java/com/prowidesoftware/swift/model/SwiftTagListBlockTest.java
@@ -65,6 +65,28 @@ public class SwiftTagListBlockTest {
     }
 
     @Test
+    public void testGetFieldsByNumberSkipsUnknownLetterOption() {
+        // an unknown letter option (no Field20Z class) must be skipped instead of aborting the conversion
+        b.append(new Tag("20", "REF1"));
+        b.append(new Tag("20Z", "SOMETHING"));
+        b.append(new Tag("20C", ":SEME//REF2"));
+
+        List<? extends Field> fields = b.getFieldsByNumber(20);
+        assertEquals(2, fields.size());
+    }
+
+    @Test
+    public void testGetFieldByNumberAndComponentValueSkipsUnknownSibling() {
+        // an unknown letter option (no Field20Z class) must not prevent matching a known sibling such as 20C
+        b.append(new Tag("20Z", "SOMETHING"));
+        b.append(new Tag("20C", ":SEME//REFERENCE"));
+
+        Field f = b.getFieldByNumber(20, "SEME");
+        assertNotNull(f);
+        assertEquals("REFERENCE", f.getComponent(2));
+    }
+
+    @Test
     public void testContainsAll() {
         b.append(t);
         b.append(new Tag("1", "val"));


### PR DESCRIPTION
## Problem

`SwiftTagListBlock.getFieldsByNumber(int)` throws `IllegalArgumentException("Unable to create field for tagname ...")` whenever a matching tag cannot be converted into a `Field`. This happens when a message contains a letter option for which the running library version has no field class — for example a `20U` tag on an older SRU that predates `Field20U`.

Because `getFieldByNumber(int, String)` is composed on this method, `SwiftMessageUtils.reference()` fails on category-5 messages while looking up `20C:SEME`, purely because of the unrelated `20`-numbered sibling tag (e.g. `20U`) it cannot instantiate.

## Why this is a bug

- `Field.getField()` is intentionally null-tolerant (it catches `ClassNotFoundException`, logs a warning, and returns `null`) — so the exception originates **only** from the explicit `throw` in `getFieldsByNumber`.
- Every other field lookup in the class tolerates an unconvertible tag by logging and skipping it: `getFieldByName`, `getFieldsByName`, `getTagsByName`, `getTagByName`, `getFieldByNumber(int)`, `fields()`. `getFieldsByNumber(int)` was the lone outlier.
- The throw was **undocumented** — the Javadoc `@return` even promises "an empty list if none is found" — and dates back to the initial commit alongside a TODO referencing this exact generic-vs-specific SRU field-recognition concern.

This is a forward-compatibility issue: a newer letter option in a message should never make an older library blow up on a lookup for a different, known field.

## Change

- `getFieldsByNumber(int)` now logs and skips tags that cannot be converted into a `Field`, consistently with `getFieldsByName(String, String)`.
- `getFieldByNumber(int, String)` is kept composed on it (plural + filter), preserving the overload relationship.
- Javadoc updated to describe the skip behavior.

## Tests

- `SwiftTagListBlockTest#testGetFieldsByNumberSkipsUnknownLetterOption` — direct coverage of the plural method.
- `SwiftTagListBlockTest#testGetFieldByNumberAndComponentValueSkipsUnknownSibling` — covers the `SwiftMessageUtils.reference()` path.

Both use a `20Z` tag (no `Field20Z` class exists) to reproduce the unknown-letter-option scenario; verified they fail without the fix and pass with it. The existing `Issue41` test that exercises `getFieldsByNumber` directly still passes.

## Compatibility note

This changes the behavior of the public method `getFieldsByNumber(int)` from throwing to logging-and-skipping. The throw was undocumented and contradicted the method's own `@return` contract, so reliance is unlikely — but per the project's guidance on coordinating API changes, flagging it for the maintainers and downstream consumers (prowide-iso20022, etc.).

`CHANGELOG.md` updated under 10.3.14.

## Notes for reviewers

- I was unable to run `./gradlew spotlessApply`/`spotlessCheck` in my environment (Java 11 toolchain unavailable; an unrelated pre-existing formatting violation exists in `SwiftParser.java`). Please run Spotless before merge if needed.
- I confirm this contribution may be incorporated under the project's Apache 2.0 license / Contributor License Agreement.
