### PR TITLE
(CU-86bb09hmz) Lift JAXP entity size limits so large XML parses on Java 24/25

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Prowide Core - CHANGELOG
 
+#### 10.3.17 - SNAPSHOT
+  * Fix: large XML documents with many escaped characters (e.g. camt/pacs statements) no longer fail to parse on Java 24 and newer JVMs
+
 #### 10.3.16 - July 2026
   * (PW-3251) Feat: Added `FileFormat.MX_UNWRAPPED` to identify MX payloads where the Header and Document arrive as sibling root elements with no enclosing envelope
 

--- a/src/main/java/com/prowidesoftware/swift/utils/SafeXmlUtils.java
+++ b/src/main/java/com/prowidesoftware/swift/utils/SafeXmlUtils.java
@@ -56,6 +56,31 @@ public class SafeXmlUtils {
 
     private static final String FEATURE_IGNORE_PROPERTY = "safeXmlUtils.ignore";
 
+    /**
+     * JAXP limit property bounding the size of a single general entity. JDK 24 changed its default from
+     * unlimited (0) to 100,000 (JDK-8343006), which makes parsing large documents that carry many
+     * predefined entity references (e.g. {@code &amp;}, {@code &lt;}, {@code &gt;} in narrative fields of
+     * a camt/pacs statement) fail with JAXP00010003. All the parsers built here already disable DTDs, so
+     * no custom entities can be declared and only the predefined entities may appear, each expanding 1:1
+     * with no amplification; restoring the unlimited value is therefore safe and keeps the parsing
+     * behavior stable across JDK 11/17/21/24/25.
+     */
+    private static final String MAX_GENERAL_ENTITY_SIZE_LIMIT =
+            "http://www.oracle.com/xml/jaxp/properties/maxGeneralEntitySizeLimit";
+
+    /**
+     * JAXP limit property bounding the accumulated size of all entities. Must be lifted together with
+     * {@link #MAX_GENERAL_ENTITY_SIZE_LIMIT}, otherwise a large document trips this one instead
+     * (JAXP00010004). See {@link #MAX_GENERAL_ENTITY_SIZE_LIMIT} for the safety rationale.
+     */
+    private static final String TOTAL_ENTITY_SIZE_LIMIT =
+            "http://www.oracle.com/xml/jaxp/properties/totalEntitySizeLimit";
+
+    /**
+     * Value meaning "no limit" for the entity size limit properties above.
+     */
+    private static final String UNLIMITED = "0";
+
     private SafeXmlUtils() {
         throw new AssertionError();
     }
@@ -103,6 +128,9 @@ public class SafeXmlUtils {
 
             // set parameter
             dbf.setNamespaceAware(namespaceAware);
+
+            // restore unlimited entity size limits (see MAX_GENERAL_ENTITY_SIZE_LIMIT)
+            applyEntitySizeLimits(dbf);
 
             return dbf.newDocumentBuilder();
 
@@ -185,6 +213,9 @@ public class SafeXmlUtils {
                 spf.setFeature(feature, false);
             }
 
+            // restore unlimited entity size limits (see MAX_GENERAL_ENTITY_SIZE_LIMIT)
+            applyEntitySizeLimits(reader);
+
             return reader;
 
         } catch (ParserConfigurationException | SAXException e) {
@@ -209,6 +240,9 @@ public class SafeXmlUtils {
         if (applyFeature(property)) {
             xif.setProperty(property, false);
         }
+
+        // restore unlimited entity size limits (see MAX_GENERAL_ENTITY_SIZE_LIMIT)
+        applyEntitySizeLimits(xif);
 
         return xif;
     }
@@ -295,6 +329,58 @@ public class SafeXmlUtils {
         } catch (SAXNotRecognizedException | SAXNotSupportedException e) {
             throw logAndCreateException(e, feature, Validator.class.getName());
         }
+    }
+
+    /**
+     * Sets the entity size limit properties to unlimited on a DOM factory, honoring the
+     * {@value #FEATURE_IGNORE_PROPERTY} opt-out and tolerating processors that do not recognize them.
+     */
+    private static void applyEntitySizeLimits(final DocumentBuilderFactory dbf) {
+        for (final String property : new String[] {MAX_GENERAL_ENTITY_SIZE_LIMIT, TOTAL_ENTITY_SIZE_LIMIT}) {
+            if (applyFeature(property)) {
+                try {
+                    dbf.setAttribute(property, UNLIMITED);
+                } catch (final IllegalArgumentException e) {
+                    logUnsupportedLimit(property, e);
+                }
+            }
+        }
+    }
+
+    /**
+     * Sets the entity size limit properties to unlimited on a SAX reader, honoring the
+     * {@value #FEATURE_IGNORE_PROPERTY} opt-out and tolerating processors that do not recognize them.
+     */
+    private static void applyEntitySizeLimits(final XMLReader reader) {
+        for (final String property : new String[] {MAX_GENERAL_ENTITY_SIZE_LIMIT, TOTAL_ENTITY_SIZE_LIMIT}) {
+            if (applyFeature(property)) {
+                try {
+                    reader.setProperty(property, UNLIMITED);
+                } catch (final SAXNotRecognizedException | SAXNotSupportedException e) {
+                    logUnsupportedLimit(property, e);
+                }
+            }
+        }
+    }
+
+    /**
+     * Sets the entity size limit properties to unlimited on a StAX factory, honoring the
+     * {@value #FEATURE_IGNORE_PROPERTY} opt-out and tolerating processors that do not recognize them.
+     */
+    private static void applyEntitySizeLimits(final XMLInputFactory xif) {
+        for (final String property : new String[] {MAX_GENERAL_ENTITY_SIZE_LIMIT, TOTAL_ENTITY_SIZE_LIMIT}) {
+            if (applyFeature(property)) {
+                try {
+                    xif.setProperty(property, UNLIMITED);
+                } catch (final IllegalArgumentException e) {
+                    logUnsupportedLimit(property, e);
+                }
+            }
+        }
+    }
+
+    private static void logUnsupportedLimit(final String property, final Exception e) {
+        log.log(Level.FINE, e, () -> "XML processor does not support the entity size limit property " + property);
     }
 
     private static boolean applyFeature(final String feature) {

--- a/src/test/java/com/prowidesoftware/swift/utils/SafeXmlUtilsTest.java
+++ b/src/test/java/com/prowidesoftware/swift/utils/SafeXmlUtilsTest.java
@@ -18,8 +18,11 @@ import javax.xml.validation.Schema;
 import javax.xml.validation.SchemaFactory;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
+import org.xml.sax.InputSource;
 import org.xml.sax.SAXException;
 import org.xml.sax.SAXParseException;
+import org.xml.sax.XMLReader;
+import org.xml.sax.helpers.DefaultHandler;
 
 class SafeXmlUtilsTest {
 
@@ -69,6 +72,59 @@ class SafeXmlUtilsTest {
     @Test
     void testTransformer() {
         assertDoesNotThrow(SafeXmlUtils::transformer);
+    }
+
+    /**
+     * Builds a large XML document carrying more than 100,000 predefined entity references. JDK 24 lowered
+     * the default {@code jdk.xml.maxGeneralEntitySizeLimit} to 100,000, so before the fix this trips
+     * JAXP00010003 / JAXP00010004 and the parse fails; it is a proxy for real large camt/pacs statements
+     * whose narrative fields escape {@code &}, {@code <} and {@code >}.
+     */
+    private static String largeEntityHeavyXml() {
+        // 3 entity references per entry x 40,000 entries = 120,000 references (> the 100,000 limit)
+        StringBuilder sb = new StringBuilder(4 * 1024 * 1024);
+        sb.append("<Document><Stmt>");
+        for (int i = 0; i < 40_000; i++) {
+            sb.append("<Ntry><Inf>José &amp; Co &lt;Ltd&gt;</Inf></Ntry>");
+        }
+        sb.append("</Stmt></Document>");
+        return sb.toString();
+    }
+
+    /**
+     * A large entity-heavy document parses through the DOM builder (JDK 24+ entity size limits lifted).
+     */
+    @Test
+    void testDocumentBuilderParsesLargeEntityHeavyDocument() {
+        String xml = largeEntityHeavyXml();
+        assertDoesNotThrow(() -> SafeXmlUtils.documentBuilder(true).parse(new InputSource(new StringReader(xml))));
+    }
+
+    /**
+     * A large entity-heavy document parses through the SAX reader (JDK 24+ entity size limits lifted).
+     */
+    @Test
+    void testReaderParsesLargeEntityHeavyDocument() {
+        String xml = largeEntityHeavyXml();
+        assertDoesNotThrow(() -> {
+            XMLReader reader = SafeXmlUtils.reader(true, null);
+            reader.setContentHandler(new DefaultHandler());
+            reader.parse(new InputSource(new StringReader(xml)));
+        });
+    }
+
+    /**
+     * A large entity-heavy document parses through the StAX reader (JDK 24+ entity size limits lifted).
+     */
+    @Test
+    void testInputFactoryParsesLargeEntityHeavyDocument() {
+        String xml = largeEntityHeavyXml();
+        assertDoesNotThrow(() -> {
+            XMLStreamReader reader = SafeXmlUtils.inputFactory().createXMLStreamReader(new StringReader(xml));
+            while (reader.hasNext()) {
+                reader.next();
+            }
+        });
     }
 
     /**


### PR DESCRIPTION
## Summary
- JDK 24 ([JDK-8343006](https://bugs.openjdk.org/browse/JDK-8343006)) lowered the default `jdk.xml.maxGeneralEntitySizeLimit` from unlimited (0) to 100,000. Under `FEATURE_SECURE_PROCESSING` (enabled in `SafeXmlUtils`), parsing a large XML document with many predefined entity references (`&amp;`, `&lt;`, `&gt;` — common in camt/pacs narrative fields) then fails with `JAXP00010003` and the parse aborts. Raw document size is *not* the trigger — the accumulated entity-reference count is.
- `SafeXmlUtils` now lifts both `maxGeneralEntitySizeLimit` and `totalEntitySizeLimit` (0 = unlimited) on the **DOM**, **SAX** and **StAX** factories, guarded by the existing `safeXmlUtils.ignore` opt-out and tolerant of XML processors that do not recognize the properties.
- Safe because DTDs are already disabled (`disallow-doctype-decl` / `SUPPORT_DTD=false`), so no custom entities can be declared and only the predefined entities (1:1 expansion, no amplification) can occur — the size limits only ever bounded DTD-defined entity expansion, which is already impossible here. XXE protections are unchanged (existing XXE tests still pass).

This is the central fix for a latent runtime regression affecting every large entity-heavy XML parse on Java 24/25. It also fixes `pw-swift-integrator` and `pw-swift-iso20022` transitively (all their MX parsing routes through `SafeXmlUtils`). Surfaced by the `Test on Java 25` stage of `pw-swift-integrator`.

## Test plan
- [x] `./gradlew spotlessCheck compileJava compileTestJava` — pass
- [x] `./gradlew test --tests "*.SafeXmlUtilsTest"` on Java 11 — 15 tests, 0 failures (existing XXE tests still throw as expected)
- [x] Ran the **compiled** `SafeXmlUtils` against a >100,000 entity-reference document on **OpenJDK 25.0.1** — DOM/SAX/StAX all parse OK with the fix; all three fail with `JAXP00010003` without it
- [x] New regression tests parse the large entity-heavy document through `documentBuilder`, `reader` and `inputFactory`

Ref: ClickUp CU-86bb09hmz