### PR TITLE
(CU-86bb09qfp) Lift JAXP entity size limits so large XML parses on Java 24/25

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Prowide Core - CHANGELOG
 
+#### 10.3.17 - SNAPSHOT
+  * Fix: large XML documents with many escaped characters (e.g. camt/pacs statements) no longer fail to parse on Java 24 and newer JVMs
+
 #### 10.3.16 - July 2026
   * (PW-3251) Feat: Added `FileFormat.MX_UNWRAPPED` to identify MX payloads where the Header and Document arrive as sibling root elements with no enclosing envelope
 

--- a/build.gradle
+++ b/build.gradle
@@ -344,6 +344,27 @@ tasks.register('testOn21', Test) {
     }
 }
 
+// Runs the suite on a Java 25 toolchain to verify the Java 11 artifacts execute correctly on Java 25.
+// Needed to catch JDK-version behavior changes (e.g. JDK 24 tightened the JAXP entity size limits) that
+// cannot manifest on the Java 11/17/21 the build otherwise uses. JDK 25 must be available to the Gradle
+// toolchain (CI passes -Porg.gradle.java.installations.paths=/pw/dev/jdk25).
+tasks.register('testOn25', Test) {
+    description = 'Runs tests using a Java 25 toolchain to verify compatibility'
+    group = 'verification'
+    useJUnitPlatform()
+    javaLauncher = javaToolchains.launcherFor {
+        languageVersion = JavaLanguageVersion.of(25)
+    }
+    testClassesDirs = sourceSets.test.output.classesDirs
+    classpath = sourceSets.test.runtimeClasspath
+    reports {
+        html.required = true
+        html.outputLocation = layout.buildDirectory.dir("reports/tests/testOn25")
+    }
+    binaryResultsDirectory = layout.buildDirectory.dir("test-results/testOn25")
+    dependsOn testClasses
+}
+
 jacocoTestReport {
     reports {
         xml.required.set(true)

--- a/src/main/java/com/prowidesoftware/swift/utils/SafeXmlUtils.java
+++ b/src/main/java/com/prowidesoftware/swift/utils/SafeXmlUtils.java
@@ -47,6 +47,12 @@ import org.xml.sax.XMLReader;
  * When the dependencies cannot be changed, you can ignore the error by adding a pw-swift-core.properties file in the
  * application classpath with a safeXmlUtils.ignore=featureName,featureName,featureName property. This will prevent the
  * indicated features to be applied.
+ * <p>
+ * Since 10.3.17 the DOM, SAX and StAX parsers also restore the JDK entity size limits
+ * (jdk.xml.maxGeneralEntitySizeLimit and jdk.xml.totalEntitySizeLimit) to unlimited, so large documents with many
+ * escaped characters keep parsing on JDK 24+ (JDK-8343006 lowered the general entity limit to 100,000). These limit
+ * properties participate in the same safeXmlUtils.ignore opt-out: listing them keeps the JDK-default limits in place.
+ * The restore is applied only while DTD blocking is active, so it never widens the entity-expansion DoS surface.
  *
  * @since 8.0.5
  */
@@ -56,14 +62,19 @@ public class SafeXmlUtils {
 
     private static final String FEATURE_IGNORE_PROPERTY = "safeXmlUtils.ignore";
 
+    /** Xerces feature that blocks DTDs, and therefore any custom (internal or external) entity declaration. */
+    private static final String DISALLOW_DOCTYPE_FEATURE = "http://apache.org/xml/features/disallow-doctype-decl";
+
     /**
      * JAXP limit property bounding the size of a single general entity. JDK 24 changed its default from
      * unlimited (0) to 100,000 (JDK-8343006), which makes parsing large documents that carry many
      * predefined entity references (e.g. {@code &amp;}, {@code &lt;}, {@code &gt;} in narrative fields of
-     * a camt/pacs statement) fail with JAXP00010003. All the parsers built here already disable DTDs, so
-     * no custom entities can be declared and only the predefined entities may appear, each expanding 1:1
-     * with no amplification; restoring the unlimited value is therefore safe and keeps the parsing
-     * behavior stable across JDK 11/17/21/24/25.
+     * a camt/pacs statement) fail with JAXP00010003. The parsers built here disable DTDs, so no custom
+     * entities can be declared and only the predefined entities may appear, each expanding 1:1 with no
+     * amplification; restoring the unlimited value is therefore safe and keeps the parsing behavior stable
+     * across JDK 11/17/21/24/25. To keep that rationale sound even when DTD blocking is switched off via
+     * {@value #FEATURE_IGNORE_PROPERTY}, the restore is applied only while DTD blocking is actually active
+     * (see {@link #applyEntitySizeLimits(boolean, LimitSetter)}).
      */
     private static final String MAX_GENERAL_ENTITY_SIZE_LIMIT =
             "http://www.oracle.com/xml/jaxp/properties/maxGeneralEntitySizeLimit";
@@ -129,8 +140,8 @@ public class SafeXmlUtils {
             // set parameter
             dbf.setNamespaceAware(namespaceAware);
 
-            // restore unlimited entity size limits (see MAX_GENERAL_ENTITY_SIZE_LIMIT)
-            applyEntitySizeLimits(dbf);
+            // restore unlimited entity size limits, only while DTD blocking is active (see javadoc)
+            applyEntitySizeLimits(applyFeature(DISALLOW_DOCTYPE_FEATURE), dbf::setAttribute);
 
             return dbf.newDocumentBuilder();
 
@@ -176,7 +187,7 @@ public class SafeXmlUtils {
             }
 
             // Xerces 2 only - http://xerces.apache.org/xerces-j/features.html#external-general-entities
-            feature = "http://apache.org/xml/features/disallow-doctype-decl";
+            feature = DISALLOW_DOCTYPE_FEATURE;
             if (applyFeature(feature)) {
                 spf.setFeature(feature, true);
             }
@@ -190,31 +201,32 @@ public class SafeXmlUtils {
             SAXParser saxParser = spf.newSAXParser();
             XMLReader reader = saxParser.getXMLReader();
 
-            // Using the XMLReader's setFeature
+            // Set the features on the reader itself: the factory is already built, so changing it here
+            // would not propagate to this reader. These reinforce the factory settings applied above.
 
-            feature = "http://apache.org/xml/features/disallow-doctype-decl";
+            feature = DISALLOW_DOCTYPE_FEATURE;
             if (applyFeature(feature)) {
-                spf.setFeature(feature, true);
+                reader.setFeature(feature, true);
             }
 
             // This may not be strictly required as DTDs shouldn't be allowed at all, per previous line.
             feature = "http://apache.org/xml/features/nonvalidating/load-external-dtd";
             if (applyFeature(feature)) {
-                spf.setFeature(feature, false);
+                reader.setFeature(feature, false);
             }
 
             feature = "http://xml.org/sax/features/external-general-entities";
             if (applyFeature(feature)) {
-                spf.setFeature(feature, false);
+                reader.setFeature(feature, false);
             }
 
             feature = "http://xml.org/sax/features/external-parameter-entities";
             if (applyFeature(feature)) {
-                spf.setFeature(feature, false);
+                reader.setFeature(feature, false);
             }
 
-            // restore unlimited entity size limits (see MAX_GENERAL_ENTITY_SIZE_LIMIT)
-            applyEntitySizeLimits(reader);
+            // restore unlimited entity size limits, only while DTD blocking is active (see javadoc)
+            applyEntitySizeLimits(applyFeature(DISALLOW_DOCTYPE_FEATURE), reader::setProperty);
 
             return reader;
 
@@ -241,8 +253,8 @@ public class SafeXmlUtils {
             xif.setProperty(property, false);
         }
 
-        // restore unlimited entity size limits (see MAX_GENERAL_ENTITY_SIZE_LIMIT)
-        applyEntitySizeLimits(xif);
+        // restore unlimited entity size limits, only while DTD support is disabled (see javadoc)
+        applyEntitySizeLimits(applyFeature(XMLInputFactory.SUPPORT_DTD), xif::setProperty);
 
         return xif;
     }
@@ -332,55 +344,45 @@ public class SafeXmlUtils {
     }
 
     /**
-     * Sets the entity size limit properties to unlimited on a DOM factory, honoring the
-     * {@value #FEATURE_IGNORE_PROPERTY} opt-out and tolerating processors that do not recognize them.
+     * Applies a single JAXP limit property. The concrete call differs per parser API
+     * ({@code DocumentBuilderFactory.setAttribute}, {@code XMLReader.setProperty},
+     * {@code XMLInputFactory.setProperty}), each of which may throw a checked or unchecked exception.
      */
-    private static void applyEntitySizeLimits(final DocumentBuilderFactory dbf) {
-        for (final String property : new String[] {MAX_GENERAL_ENTITY_SIZE_LIMIT, TOTAL_ENTITY_SIZE_LIMIT}) {
-            if (applyFeature(property)) {
-                try {
-                    dbf.setAttribute(property, UNLIMITED);
-                } catch (final IllegalArgumentException e) {
-                    logUnsupportedLimit(property, e);
-                }
-            }
-        }
+    @FunctionalInterface
+    private interface LimitSetter {
+        void set(String property, String value) throws Exception;
     }
 
     /**
-     * Sets the entity size limit properties to unlimited on a SAX reader, honoring the
-     * {@value #FEATURE_IGNORE_PROPERTY} opt-out and tolerating processors that do not recognize them.
+     * Restores the JAXP entity size limits to unlimited (0), reverting the tighter JDK 24+ defaults so that
+     * large entity-bearing documents keep parsing across JDK versions. Honors the
+     * {@value #FEATURE_IGNORE_PROPERTY} opt-out per property and tolerates processors that do not recognize
+     * the properties (unsupported ones are logged at FINE and skipped).
+     *
+     * <p>The restore is applied only when {@code dtdBlockingActive} is true, i.e. when DTDs are actually
+     * being blocked for this parser. When a deployment turns DTD blocking off through
+     * {@value #FEATURE_IGNORE_PROPERTY}, the JDK entity size limits are left untouched so they still act as a
+     * backstop against DTD-defined entity-expansion (billion laughs) memory DoS.
+     *
+     * @param dtdBlockingActive whether DTD blocking is in effect for the parser being configured
+     * @param setter            the parser-specific property setter
      */
-    private static void applyEntitySizeLimits(final XMLReader reader) {
+    private static void applyEntitySizeLimits(final boolean dtdBlockingActive, final LimitSetter setter) {
+        if (!dtdBlockingActive) {
+            return;
+        }
         for (final String property : new String[] {MAX_GENERAL_ENTITY_SIZE_LIMIT, TOTAL_ENTITY_SIZE_LIMIT}) {
             if (applyFeature(property)) {
                 try {
-                    reader.setProperty(property, UNLIMITED);
-                } catch (final SAXNotRecognizedException | SAXNotSupportedException e) {
-                    logUnsupportedLimit(property, e);
+                    setter.set(property, UNLIMITED);
+                } catch (final Exception e) {
+                    log.log(
+                            Level.FINE,
+                            e,
+                            () -> "XML processor does not support the entity size limit property " + property);
                 }
             }
         }
-    }
-
-    /**
-     * Sets the entity size limit properties to unlimited on a StAX factory, honoring the
-     * {@value #FEATURE_IGNORE_PROPERTY} opt-out and tolerating processors that do not recognize them.
-     */
-    private static void applyEntitySizeLimits(final XMLInputFactory xif) {
-        for (final String property : new String[] {MAX_GENERAL_ENTITY_SIZE_LIMIT, TOTAL_ENTITY_SIZE_LIMIT}) {
-            if (applyFeature(property)) {
-                try {
-                    xif.setProperty(property, UNLIMITED);
-                } catch (final IllegalArgumentException e) {
-                    logUnsupportedLimit(property, e);
-                }
-            }
-        }
-    }
-
-    private static void logUnsupportedLimit(final String property, final Exception e) {
-        log.log(Level.FINE, e, () -> "XML processor does not support the entity size limit property " + property);
     }
 
     private static boolean applyFeature(final String feature) {

--- a/src/main/java/com/prowidesoftware/swift/utils/SafeXmlUtils.java
+++ b/src/main/java/com/prowidesoftware/swift/utils/SafeXmlUtils.java
@@ -56,6 +56,31 @@ public class SafeXmlUtils {
 
     private static final String FEATURE_IGNORE_PROPERTY = "safeXmlUtils.ignore";
 
+    /**
+     * JAXP limit property bounding the size of a single general entity. JDK 24 changed its default from
+     * unlimited (0) to 100,000 (JDK-8343006), which makes parsing large documents that carry many
+     * predefined entity references (e.g. {@code &amp;}, {@code &lt;}, {@code &gt;} in narrative fields of
+     * a camt/pacs statement) fail with JAXP00010003. All the parsers built here already disable DTDs, so
+     * no custom entities can be declared and only the predefined entities may appear, each expanding 1:1
+     * with no amplification; restoring the unlimited value is therefore safe and keeps the parsing
+     * behavior stable across JDK 11/17/21/24/25.
+     */
+    private static final String MAX_GENERAL_ENTITY_SIZE_LIMIT =
+            "http://www.oracle.com/xml/jaxp/properties/maxGeneralEntitySizeLimit";
+
+    /**
+     * JAXP limit property bounding the accumulated size of all entities. Must be lifted together with
+     * {@link #MAX_GENERAL_ENTITY_SIZE_LIMIT}, otherwise a large document trips this one instead
+     * (JAXP00010004). See {@link #MAX_GENERAL_ENTITY_SIZE_LIMIT} for the safety rationale.
+     */
+    private static final String TOTAL_ENTITY_SIZE_LIMIT =
+            "http://www.oracle.com/xml/jaxp/properties/totalEntitySizeLimit";
+
+    /**
+     * Value meaning "no limit" for the entity size limit properties above.
+     */
+    private static final String UNLIMITED = "0";
+
     private SafeXmlUtils() {
         throw new AssertionError();
     }
@@ -103,6 +128,9 @@ public class SafeXmlUtils {
 
             // set parameter
             dbf.setNamespaceAware(namespaceAware);
+
+            // restore unlimited entity size limits (see MAX_GENERAL_ENTITY_SIZE_LIMIT)
+            applyEntitySizeLimits(dbf);
 
             return dbf.newDocumentBuilder();
 
@@ -185,6 +213,9 @@ public class SafeXmlUtils {
                 spf.setFeature(feature, false);
             }
 
+            // restore unlimited entity size limits (see MAX_GENERAL_ENTITY_SIZE_LIMIT)
+            applyEntitySizeLimits(reader);
+
             return reader;
 
         } catch (ParserConfigurationException | SAXException e) {
@@ -209,6 +240,9 @@ public class SafeXmlUtils {
         if (applyFeature(property)) {
             xif.setProperty(property, false);
         }
+
+        // restore unlimited entity size limits (see MAX_GENERAL_ENTITY_SIZE_LIMIT)
+        applyEntitySizeLimits(xif);
 
         return xif;
     }
@@ -295,6 +329,58 @@ public class SafeXmlUtils {
         } catch (SAXNotRecognizedException | SAXNotSupportedException e) {
             throw logAndCreateException(e, feature, Validator.class.getName());
         }
+    }
+
+    /**
+     * Sets the entity size limit properties to unlimited on a DOM factory, honoring the
+     * {@value #FEATURE_IGNORE_PROPERTY} opt-out and tolerating processors that do not recognize them.
+     */
+    private static void applyEntitySizeLimits(final DocumentBuilderFactory dbf) {
+        for (final String property : new String[] {MAX_GENERAL_ENTITY_SIZE_LIMIT, TOTAL_ENTITY_SIZE_LIMIT}) {
+            if (applyFeature(property)) {
+                try {
+                    dbf.setAttribute(property, UNLIMITED);
+                } catch (final IllegalArgumentException e) {
+                    logUnsupportedLimit(property, e);
+                }
+            }
+        }
+    }
+
+    /**
+     * Sets the entity size limit properties to unlimited on a SAX reader, honoring the
+     * {@value #FEATURE_IGNORE_PROPERTY} opt-out and tolerating processors that do not recognize them.
+     */
+    private static void applyEntitySizeLimits(final XMLReader reader) {
+        for (final String property : new String[] {MAX_GENERAL_ENTITY_SIZE_LIMIT, TOTAL_ENTITY_SIZE_LIMIT}) {
+            if (applyFeature(property)) {
+                try {
+                    reader.setProperty(property, UNLIMITED);
+                } catch (final SAXNotRecognizedException | SAXNotSupportedException e) {
+                    logUnsupportedLimit(property, e);
+                }
+            }
+        }
+    }
+
+    /**
+     * Sets the entity size limit properties to unlimited on a StAX factory, honoring the
+     * {@value #FEATURE_IGNORE_PROPERTY} opt-out and tolerating processors that do not recognize them.
+     */
+    private static void applyEntitySizeLimits(final XMLInputFactory xif) {
+        for (final String property : new String[] {MAX_GENERAL_ENTITY_SIZE_LIMIT, TOTAL_ENTITY_SIZE_LIMIT}) {
+            if (applyFeature(property)) {
+                try {
+                    xif.setProperty(property, UNLIMITED);
+                } catch (final IllegalArgumentException e) {
+                    logUnsupportedLimit(property, e);
+                }
+            }
+        }
+    }
+
+    private static void logUnsupportedLimit(final String property, final Exception e) {
+        log.log(Level.FINE, e, () -> "XML processor does not support the entity size limit property " + property);
     }
 
     private static boolean applyFeature(final String feature) {

--- a/src/test/java/com/prowidesoftware/swift/utils/SafeXmlUtilsTest.java
+++ b/src/test/java/com/prowidesoftware/swift/utils/SafeXmlUtilsTest.java
@@ -92,6 +92,19 @@ class SafeXmlUtilsTest {
     }
 
     /**
+     * Verifies the reader has the entity size limits actually set to unlimited. Unlike the parse tests
+     * below, this fails on every JDK if the fix is reverted (on JDK 11 the {@code totalEntitySizeLimit}
+     * default is 50,000,000, not 0), so it guards the fix on the JDK 11/17/21 the project builds and tests
+     * with — where the tightened JDK 24 defaults do not apply.
+     */
+    @Test
+    void testReaderAppliesUnlimitedEntitySizeLimits() throws Exception {
+        org.xml.sax.XMLReader reader = SafeXmlUtils.reader(true, null);
+        assertEquals("0", reader.getProperty("http://www.oracle.com/xml/jaxp/properties/totalEntitySizeLimit"));
+        assertEquals("0", reader.getProperty("http://www.oracle.com/xml/jaxp/properties/maxGeneralEntitySizeLimit"));
+    }
+
+    /**
      * A large entity-heavy document parses through the DOM builder (JDK 24+ entity size limits lifted).
      */
     @Test

--- a/src/test/java/com/prowidesoftware/swift/utils/SafeXmlUtilsTest.java
+++ b/src/test/java/com/prowidesoftware/swift/utils/SafeXmlUtilsTest.java
@@ -18,8 +18,11 @@ import javax.xml.validation.Schema;
 import javax.xml.validation.SchemaFactory;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
+import org.xml.sax.InputSource;
 import org.xml.sax.SAXException;
 import org.xml.sax.SAXParseException;
+import org.xml.sax.XMLReader;
+import org.xml.sax.helpers.DefaultHandler;
 
 class SafeXmlUtilsTest {
 
@@ -69,6 +72,59 @@ class SafeXmlUtilsTest {
     @Test
     void testTransformer() {
         assertDoesNotThrow(SafeXmlUtils::transformer);
+    }
+
+    /**
+     * Builds a large dummy XML document carrying more than 100,000 predefined entity references. JDK 24
+     * lowered the default {@code jdk.xml.maxGeneralEntitySizeLimit} to 100,000, so before the fix this
+     * trips JAXP00010003 / JAXP00010004 and the parse fails; it stands in for any large document whose
+     * text content escapes {@code &}, {@code <} and {@code >}.
+     */
+    private static String largeEntityHeavyXml() {
+        // 3 entity references per item x 40,000 items = 120,000 references (> the 100,000 limit)
+        StringBuilder sb = new StringBuilder(4 * 1024 * 1024);
+        sb.append("<root>");
+        for (int i = 0; i < 40_000; i++) {
+            sb.append("<item><note>a &amp; b &lt; c &gt; d</note></item>");
+        }
+        sb.append("</root>");
+        return sb.toString();
+    }
+
+    /**
+     * A large entity-heavy document parses through the DOM builder (JDK 24+ entity size limits lifted).
+     */
+    @Test
+    void testDocumentBuilderParsesLargeEntityHeavyDocument() {
+        String xml = largeEntityHeavyXml();
+        assertDoesNotThrow(() -> SafeXmlUtils.documentBuilder(true).parse(new InputSource(new StringReader(xml))));
+    }
+
+    /**
+     * A large entity-heavy document parses through the SAX reader (JDK 24+ entity size limits lifted).
+     */
+    @Test
+    void testReaderParsesLargeEntityHeavyDocument() {
+        String xml = largeEntityHeavyXml();
+        assertDoesNotThrow(() -> {
+            XMLReader reader = SafeXmlUtils.reader(true, null);
+            reader.setContentHandler(new DefaultHandler());
+            reader.parse(new InputSource(new StringReader(xml)));
+        });
+    }
+
+    /**
+     * A large entity-heavy document parses through the StAX reader (JDK 24+ entity size limits lifted).
+     */
+    @Test
+    void testInputFactoryParsesLargeEntityHeavyDocument() {
+        String xml = largeEntityHeavyXml();
+        assertDoesNotThrow(() -> {
+            XMLStreamReader reader = SafeXmlUtils.inputFactory().createXMLStreamReader(new StringReader(xml));
+            while (reader.hasNext()) {
+                reader.next();
+            }
+        });
     }
 
     /**


### PR DESCRIPTION
## Summary
- JDK 24 ([JDK-8343006](https://bugs.openjdk.org/browse/JDK-8343006)) lowered the default `jdk.xml.maxGeneralEntitySizeLimit` from unlimited (0) to 100,000. Under `FEATURE_SECURE_PROCESSING` (enabled in `SafeXmlUtils`), parsing a large XML document with many predefined entity references (`&amp;`, `&lt;`, `&gt;` in escaped text content) then fails with `JAXP00010003` and the parse aborts. Raw document size is *not* the trigger — the accumulated entity-reference count is.
- `SafeXmlUtils` now lifts both `maxGeneralEntitySizeLimit` and `totalEntitySizeLimit` (0 = unlimited) on the **DOM**, **SAX** and **StAX** factories, guarded by the existing `safeXmlUtils.ignore` opt-out and tolerant of XML processors that do not recognize the properties.
- Safe because DTDs are already disabled (`disallow-doctype-decl` / `SUPPORT_DTD=false`), so no custom entities can be declared and only the predefined entities (1:1 expansion, no amplification) can occur — the size limits only ever bounded DTD-defined entity expansion, which is already impossible here. XXE protections are unchanged (existing XXE tests still pass).

This is the central fix for a latent runtime regression affecting every large entity-heavy XML parse on Java 24/25. It also fixes `pw-swift-iso20022` and `pw-swift-integrator` transitively (all their MX parsing routes through `SafeXmlUtils`). Surfaced by the `Test on Java 25` stage of `pw-swift-integrator`.

## Test plan
- [x] `./gradlew spotlessCheck compileJava compileTestJava` — pass
- [x] `./gradlew test --tests "*.SafeXmlUtilsTest"` on Java 11 — 15 tests, 0 failures (existing XXE tests still throw as expected)
- [x] Ran the **compiled** `SafeXmlUtils` against a >100,000 entity-reference dummy document on **OpenJDK 25.0.1** — DOM/SAX/StAX all parse OK with the fix; all three fail with `JAXP00010003` without it
- [x] New regression tests parse the large entity-heavy dummy document through `documentBuilder`, `reader` and `inputFactory`

Companion PR: prowide-iso20022 (large-document MX parse regression test). Ref: ClickUp CU-86bb09qfp