### PR TITLE
(GH-341) Issues with SwiftMessageUtilsmoney for Category 7 messages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Prowide Core - CHANGELOG
 
 #### 10.3.19 - SNAPSHOT
+  * (GH-341) Fix: `SwiftMessageUtils.money` revised for category 7: amount added for MT744, MT760, MT765 and MT786; changed to field 32B for MT750 and MT752, and to 34B for MT769; removed for MT707
   * (PW-3433) Fix: `OptionJPartyField.getValueByCodeword` no longer shifts the codeword/value pairs that follow a codeword with a blank value (for example "/CITY/" followed by "/USFW/021000018" returned "USFW" for CITY and null for USFW); a codeword present with a blank value now returns an empty string
 
 #### 10.3.18 - August 2026

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,8 @@
 # Prowide Core - CHANGELOG
 
 #### 10.3.19 - SNAPSHOT
-  * (GH-341) Fix: `SwiftMessageUtils.money` revised for category 7: amount added for MT744, MT760, MT765 and MT786; changed to field 32B for MT750 and MT752, and to 34B for MT769; removed for MT707
   * (PW-3433) Fix: `OptionJPartyField.getValueByCodeword` no longer shifts the codeword/value pairs that follow a codeword with a blank value (for example "/CITY/" followed by "/USFW/021000018" returned "USFW" for CITY and null for USFW); a codeword present with a blank value now returns an empty string
+  * (GH-341) Fix: `SwiftMessageUtils.money` revised for category 7: amount added for MT744, MT760, MT765 and MT786; changed to field 32B for MT750 and MT752, and to 34B for MT769; removed for MT707
 
 #### 10.3.18 - August 2026
   * (GH-338) Fix: no-arg getters of subsequences with delimiters shared by another sequence in the same message are now resolved within their parent sequence, not the whole block 4; fixes `MT360`/`MT361` `getSequenceE1()`, `getSequenceF1()` and `getSequenceF2()` returning sequence B/C content. Affected subsequences are flagged with `@NonUniqueSeparator`

--- a/src/main/java/com/prowidesoftware/swift/model/SwiftMessageUtils.java
+++ b/src/main/java/com/prowidesoftware/swift/model/SwiftMessageUtils.java
@@ -745,7 +745,7 @@ public class SwiftMessageUtils {
             return Money.of(b4.getFieldByName("32A"));
         } else if (m.isType(
                 191, 291, 300, 304, 305, 320, 391, 491, 591, 691, 791, 891, 991, 340, 341, 350, 360, 361, 364, 365, 620,
-                700, 705, 710, 720, 732, 740, 742, 756)) {
+                700, 705, 710, 720, 732, 740, 742, 750, 752, 756, 760, 765, 786)) {
             return Money.of(b4.getFieldByName("32B"));
         } else if (m.isType(
                 321, 370, 508, 509, 535, 536, 537, 540, 541, 542, 543, 544, 545, 546, 547, 548, 558, 559, 569, 574, 575,
@@ -753,7 +753,7 @@ public class SwiftMessageUtils {
             return Money.of(b4.getFieldByName("19A"));
         } else if (m.isType(330, 362)) {
             return Money.of(b4.getFieldByName("32H"));
-        } else if (m.isType(306, 581, 707, 747)) {
+        } else if (m.isType(306, 581, 747, 769)) {
             return Money.of(b4.getFieldByName("34B"));
         } else if (m.isType(380, 381, 505, 564, 566, 567)) {
             return Money.of(b4.getFieldByName("19B"));
@@ -776,12 +776,8 @@ public class SwiftMessageUtils {
             return Money.ofAny(b4, "32A", "32B", "32K");
         } else if (m.isType(430)) {
             return Money.ofAny(b4, "33A", "33K", "32A", "32K");
-        } else if (m.isType(750)) {
-            return Money.ofAny(b4, "34B", "32B");
-        } else if (m.isType(752)) {
-            return Money.ofAny(b4, "33A", "33B", "32B");
-        } else if (m.isType(769)) {
-            return Money.ofAny(b4, "32B", "32D", "33B", "34B");
+        } else if (m.isType(744)) {
+            return Money.ofAny(b4, "34A", "34B");
         } else if (m.isType(940, 950, 970)) {
             return Money.ofAny(b4, "62F", "62M");
         } else if (m.isType(101, 201, 203, 204, 207, 210)) {

--- a/src/test/java/com/prowidesoftware/swift/model/SwiftMessageUtilsTest.java
+++ b/src/test/java/com/prowidesoftware/swift/model/SwiftMessageUtilsTest.java
@@ -358,6 +358,43 @@ public class SwiftMessageUtilsTest {
     }
 
     @Test
+    public void testMoneyMT760SequenceC() throws IOException {
+        // when the optional sequence C (local undertaking details) also contains a 32B, the main
+        // amount is still the undertaking amount in the first 32B occurrence (sequence B)
+        final String fin = "{1:F01AAAAUS33AXXX0000000000}{2:I760BBBBUS33XXXXN}{4:\n"
+                + ":15A:\n"
+                + ":27:1/1\n"
+                + ":22A:ISSU\n"
+                + ":15B:\n"
+                + ":20:FOO\n"
+                + ":30:250820\n"
+                + ":22D:DGAR\n"
+                + ":40C:NONE\n"
+                + ":23B:FIXD\n"
+                + ":35G:If things happen\n"
+                + ":50:The applicant\n"
+                + ":52D:The issuer\n"
+                + ":59:The beneficiary\n"
+                + ":32B:USD5000,\n"
+                + ":77U:The terms and conditions\n"
+                + ":45L:The underlying transaction\n"
+                + ":15C:\n"
+                + ":22D:DGAR\n"
+                + ":40C:NONE\n"
+                + ":23B:FIXD\n"
+                + ":35G:If local things happen\n"
+                + ":50:The applicant\n"
+                + ":59:The local beneficiary\n"
+                + ":32B:EUR9999,\n"
+                + ":77L:The local terms and conditions\n"
+                + "-}";
+        Money money = SwiftMessageUtils.money(SwiftMessage.parse(fin));
+        assertNotNull(money);
+        assertEquals("USD", money.getCurrency());
+        assertEquals(new BigDecimal("5000"), money.getAmount());
+    }
+
+    @Test
     public void testMoneyMT765() throws IOException {
         // the main amount is the demand amount in field 32B
         final String fin = "{1:F01AAAAUS33AXXX0000000000}{2:I765BBBBUS33XXXXN}{4:\n"
@@ -387,6 +424,35 @@ public class SwiftMessageUtilsTest {
         assertNotNull(money);
         assertEquals("USD", money.getCurrency());
         assertEquals(new BigDecimal("1500"), money.getAmount());
+    }
+
+    @Test
+    public void testMoneyMT769WithoutAmountOutstanding() throws IOException {
+        // when the optional 34B amount outstanding is absent there is no main amount, the
+        // amount of charges in fields 32a must never be used as a fallback
+        final String fin = "{1:F01AAAAUS33AXXX0000000000}{2:I769BBBBUS33XXXXN}{4:\n"
+                + ":20:FOO\n"
+                + ":21:BAR\n"
+                + ":32B:USD10,\n"
+                + ":33B:USD500,\n"
+                + "-}";
+        assertNull(SwiftMessageUtils.money(SwiftMessage.parse(fin)));
+    }
+
+    @Test
+    public void testMoneyMT747() throws IOException {
+        // regression guard for the 34B group: MT747 main amount remains the 34B decrease of
+        // documentary credit amount
+        final String fin = "{1:F01AAAAUS33AXXX0000000000}{2:I747BBBBUS33XXXXN}{4:\n"
+                + ":20:FOO\n"
+                + ":21:BAR\n"
+                + ":30:250820\n"
+                + ":34B:USD777,77\n"
+                + "-}";
+        Money money = SwiftMessageUtils.money(SwiftMessage.parse(fin));
+        assertNotNull(money);
+        assertEquals("USD", money.getCurrency());
+        assertEquals(new BigDecimal("777.77"), money.getAmount());
     }
 
     @Test

--- a/src/test/java/com/prowidesoftware/swift/model/SwiftMessageUtilsTest.java
+++ b/src/test/java/com/prowidesoftware/swift/model/SwiftMessageUtilsTest.java
@@ -258,6 +258,152 @@ public class SwiftMessageUtilsTest {
     }
 
     @Test
+    public void testMoneyMT707() throws IOException {
+        // field 34B is not part of the MT707 format since SRU2018, thus no main amount is defined,
+        // even if a legacy message contains a 34B tag
+        final String fin = "{1:F01AAAAUS33AXXX0000000000}{2:I707BBBBUS33XXXXN}{4:\n"
+                + ":20:FOO\n"
+                + ":21:BAR\n"
+                + ":32B:USD1000,\n"
+                + ":33B:USD2000,\n"
+                + ":34B:USD3000,\n"
+                + "-}";
+        assertNull(SwiftMessageUtils.money(SwiftMessage.parse(fin)));
+    }
+
+    @Test
+    public void testMoneyMT744_34A() throws IOException {
+        final String fin = "{1:F01AAAAUS33AXXX0000000000}{2:I744BBBBUS33XXXXN}{4:\n"
+                + ":20:FOO\n"
+                + ":21:BAR\n"
+                + ":34A:250820USD1234,56\n"
+                + "-}";
+        Money money = SwiftMessageUtils.money(SwiftMessage.parse(fin));
+        assertNotNull(money);
+        assertEquals("USD", money.getCurrency());
+        assertEquals(new BigDecimal("1234.56"), money.getAmount());
+    }
+
+    @Test
+    public void testMoneyMT744_34B() throws IOException {
+        final String fin = "{1:F01AAAAUS33AXXX0000000000}{2:I744BBBBUS33XXXXN}{4:\n"
+                + ":20:FOO\n"
+                + ":21:BAR\n"
+                + ":34B:USD1234,56\n"
+                + "-}";
+        Money money = SwiftMessageUtils.money(SwiftMessage.parse(fin));
+        assertNotNull(money);
+        assertEquals("USD", money.getCurrency());
+        assertEquals(new BigDecimal("1234.56"), money.getAmount());
+    }
+
+    @Test
+    public void testMoneyMT750() throws IOException {
+        // the main amount is the principal amount in field 32B, not the total amount claimed in 34B
+        final String fin = "{1:F01AAAAUS33AXXX0000000000}{2:I750BBBBUS33XXXXN}{4:\n"
+                + ":20:FOO\n"
+                + ":21:BAR\n"
+                + ":32B:USD1000,\n"
+                + ":33B:USD200,\n"
+                + ":34B:USD1200,\n"
+                + "-}";
+        Money money = SwiftMessageUtils.money(SwiftMessage.parse(fin));
+        assertNotNull(money);
+        assertEquals("USD", money.getCurrency());
+        assertEquals(new BigDecimal("1000"), money.getAmount());
+    }
+
+    @Test
+    public void testMoneyMT752() throws IOException {
+        // the main amount is the total amount advised in field 32B, not the net amount in 33a
+        final String fin = "{1:F01AAAAUS33AXXX0000000000}{2:I752BBBBUS33XXXXN}{4:\n"
+                + ":20:FOO\n"
+                + ":21:BAR\n"
+                + ":23:PREADV\n"
+                + ":32B:USD1000,\n"
+                + ":33A:250820USD980,\n"
+                + "-}";
+        Money money = SwiftMessageUtils.money(SwiftMessage.parse(fin));
+        assertNotNull(money);
+        assertEquals("USD", money.getCurrency());
+        assertEquals(new BigDecimal("1000"), money.getAmount());
+    }
+
+    @Test
+    public void testMoneyMT760() throws IOException {
+        // the main amount is the undertaking amount in field 32B
+        final String fin = "{1:F01AAAAUS33AXXX0000000000}{2:I760BBBBUS33XXXXN}{4:\n"
+                + ":15A:\n"
+                + ":27:1/1\n"
+                + ":22A:ISSU\n"
+                + ":15B:\n"
+                + ":20:FOO\n"
+                + ":30:250820\n"
+                + ":22D:DGAR\n"
+                + ":40C:NONE\n"
+                + ":23B:FIXD\n"
+                + ":35G:If things happen\n"
+                + ":50:The applicant\n"
+                + ":51:The obligor\n"
+                + ":52D:The issuer\n"
+                + ":59:The beneficiary\n"
+                + ":32B:USD5000,\n"
+                + ":77U:The terms and conditions\n"
+                + ":45L:The underlying transaction\n"
+                + "-}";
+        Money money = SwiftMessageUtils.money(SwiftMessage.parse(fin));
+        assertNotNull(money);
+        assertEquals("USD", money.getCurrency());
+        assertEquals(new BigDecimal("5000"), money.getAmount());
+    }
+
+    @Test
+    public void testMoneyMT765() throws IOException {
+        // the main amount is the demand amount in field 32B
+        final String fin = "{1:F01AAAAUS33AXXX0000000000}{2:I765BBBBUS33XXXXN}{4:\n"
+                + ":20:FOO\n"
+                + ":21:BAR\n"
+                + ":31C:250820\n"
+                + ":32B:USD3000,\n"
+                + "-}";
+        Money money = SwiftMessageUtils.money(SwiftMessage.parse(fin));
+        assertNotNull(money);
+        assertEquals("USD", money.getCurrency());
+        assertEquals(new BigDecimal("3000"), money.getAmount());
+    }
+
+    @Test
+    public void testMoneyMT769() throws IOException {
+        // the main amount is the amount outstanding in field 34B, the amount of charges in
+        // fields 32a cannot be the main amount
+        final String fin = "{1:F01AAAAUS33AXXX0000000000}{2:I769BBBBUS33XXXXN}{4:\n"
+                + ":20:FOO\n"
+                + ":21:BAR\n"
+                + ":32B:USD10,\n"
+                + ":33B:USD500,\n"
+                + ":34B:USD1500,\n"
+                + "-}";
+        Money money = SwiftMessageUtils.money(SwiftMessage.parse(fin));
+        assertNotNull(money);
+        assertEquals("USD", money.getCurrency());
+        assertEquals(new BigDecimal("1500"), money.getAmount());
+    }
+
+    @Test
+    public void testMoneyMT786() throws IOException {
+        // the main amount is the principal amount in field 32B
+        final String fin = "{1:F01AAAAUS33AXXX0000000000}{2:I786BBBBUS33XXXXN}{4:\n"
+                + ":20:FOO\n"
+                + ":21:BAR\n"
+                + ":32B:USD2000,\n"
+                + "-}";
+        Money money = SwiftMessageUtils.money(SwiftMessage.parse(fin));
+        assertNotNull(money);
+        assertEquals("USD", money.getCurrency());
+        assertEquals(new BigDecimal("2000"), money.getAmount());
+    }
+
+    @Test
     public void testValueDate() throws IOException, ParseException {
 
         // MT305


### PR DESCRIPTION
## Summary
- `SwiftMessageUtils.money` revised for Category 7 (GH-341): main amount added for MT744 (34a), MT760, MT765 and MT786 (32B); changed to field 32B for MT750 and MT752; changed to 34B (amount outstanding) for MT769; removed for MT707 (34B is not part of the format since SRU2018)
- Field expectations validated against the SRU2025 MFVR (Part V, chapter 7) and the generated MT7xx model
- Note for downstream consumers: `money()` feeds `DefaultMtMetadataStrategy.amount()`, so the persisted `currency`/`amount` metadata of `MtSwiftMessage` changes for MT707/750/752/769 traffic

## Test plan
- [x] New unit tests for each affected MT (707, 744 both 34a options, 750, 752, 760, 765, 769, 786) with distinct amounts per field to prove field precedence
- [x] Hardening tests: MT760 with 32B in both sequence B and C, MT769 without 34B returns null, MT747 regression guard for the 34B group
- [x] Full `./gradlew test` suite green, `spotlessCheck` green

🤖 Generated with [Claude Code](https://claude.com/claude-code)