### PR TITLE
Support the nested blocks of MT021, MT056 and MT096 in the parser

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Prowide Core - CHANGELOG
 
+#### 10.3.20 - SNAPSHOT
+  * Fix: the message nested in the block 4 of an MT021, MT056 or MT096 is no longer truncated at the first closing brace, so these messages are parsed and written back intact
+  * Feat: `SwiftParser.parseBlock3` and `SwiftParser.parseBlock5` also accept the block content without the block identifier, as it is found in the nested blocks of an MT021 or MT096
+
 #### 10.3.19 - August 2026
   * (PW-3433) Fix: `OptionJPartyField.getValueByCodeword` no longer shifts the codeword/value pairs that follow a codeword with a blank value (for example "/CITY/" followed by "/USFW/021000018" returned "USFW" for CITY and null for USFW); a codeword present with a blank value now returns an empty string
   * (GH-341) Fix: `SwiftMessageUtils.money` revised for category 7: amount added for MT744, MT760, MT765 and MT786; changed to field 32B for MT750 and MT752, and to 34B for MT769; removed for MT707

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,8 @@
 # Prowide Core - CHANGELOG
 
 #### 10.3.20 - SNAPSHOT
-  * Fix: the message nested in the block 4 of an MT021, MT056 or MT096 is no longer truncated at the first closing brace, so these messages are parsed and written back intact
-  * Feat: `SwiftParser.parseBlock3` and `SwiftParser.parseBlock5` also accept the block content without the block identifier, as it is found in the nested blocks of an MT021 or MT096
+  * Fix: the message nested in the block 4 of the system messages MT021, MT056 and MT096 is no longer truncated at the first closing brace, so these messages are parsed and written back intact; the tag value is read balancing the curly braces for the tag names where SWIFT defines nested blocks (the block identifiers 1 to 5 and the field 270), while any other tag keeps the historical reading, ending at the first closing brace
+  * Feat: `SwiftParser.parseBlock3` and `SwiftParser.parseBlock5` also accept the block content without the block identifier, as it is found in the nested blocks of an MT021 or MT096, and return an empty block for a null content
 
 #### 10.3.19 - August 2026
   * (PW-3433) Fix: `OptionJPartyField.getValueByCodeword` no longer shifts the codeword/value pairs that follow a codeword with a blank value (for example "/CITY/" followed by "/USFW/021000018" returned "USFW" for CITY and null for USFW); a codeword present with a blank value now returns an empty string

--- a/src/main/java/com/prowidesoftware/swift/io/parser/SwiftParser.java
+++ b/src/main/java/com/prowidesoftware/swift/io/parser/SwiftParser.java
@@ -21,7 +21,11 @@ import com.prowidesoftware.swift.utils.Lib;
 import java.io.*;
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Set;
 import org.apache.commons.lang3.StringUtils;
 
 /**
@@ -39,6 +43,26 @@ public class SwiftParser {
 
     private static final transient java.util.logging.Logger log =
             java.util.logging.Logger.getLogger(SwiftParser.class.getName());
+
+    /**
+     * Names of the tags that convey nested blocks within a tag list block, and whose value is therefore read
+     * balancing the curly braces instead of ending at the first closing brace.
+     *
+     * <p>These are the only nested block definitions in the standard:
+     * <ul>
+     * <li>the block identifiers 1 to 5, used by the retrieved message of the MT021 (conveyed as the block 1, 2 and 3
+     * headers, the block 4 text and the block 5 trailers) and by the copied message of the MT096 (conveyed as a
+     * complete block 1 to 5 message)</li>
+     * <li>the field 270 of the MT056, where every login attempt embeds a login block and an optional login result,
+     * each one made of a block 1 and a block 4</li>
+     * </ul>
+     *
+     * <p>Any other tag keeps the historical reading, ending at the first closing brace. This is relevant for
+     * malformed content such as a service message error code that is not properly closed before the next field.
+     */
+    private static final Set<String> NESTED_BLOCK_TAG_NAMES =
+            Collections.unmodifiableSet(new HashSet<>(Arrays.asList("1", "2", "3", "4", "5", "270")));
+
     /**
      * Errors found while parsing the message.
      */
@@ -156,27 +180,48 @@ public class SwiftParser {
     /**
      * Parses a string containing an MT message block 3 content
      *
-     * @param s block content starting with "{3:" and ending with "}"
+     * @param s block content starting with "{3:" and ending with "}", or the block tags alone, without the block
+     *          identifier, as they are found nested in the block 4 of an MT021 or MT096
      * @return content parsed into a block 3 or an empty block 3 if string cannot be parsed
      * @since 7.8.6
      */
     public static SwiftBlock3 parseBlock3(String s) {
         SwiftBlock3 b3 = new SwiftBlock3();
         SwiftParser parser = new SwiftParser();
-        return (SwiftBlock3) parser.consumeTagListBlock(b3, s);
+        return (SwiftBlock3) parser.consumeTagListBlock(b3, withBlockIdentifier(s, '3'));
     }
 
     /**
      * Parses a string containing an MT message block 5 content
      *
-     * @param s block content starting with "{5:" and ending with "}"
+     * @param s block content starting with "{5:" and ending with "}", or the block tags alone, without the block
+     *          identifier, as they are found nested in the block 4 of an MT021 or MT096
      * @return content parsed into a block 5 or an empty block 5 if string cannot be parsed
      * @since 7.8.6
      */
     public static SwiftBlock5 parseBlock5(String s) {
         SwiftBlock5 b5 = new SwiftBlock5();
         SwiftParser parser = new SwiftParser();
-        return (SwiftBlock5) parser.consumeTagListBlock(b5, s);
+        return (SwiftBlock5) parser.consumeTagListBlock(b5, withBlockIdentifier(s, '5'));
+    }
+
+    /**
+     * Prepends the block identifier to a tag list block content when it is not present, leaving the content
+     * untouched otherwise.
+     *
+     * <p>This makes the block content of a nested block, as returned by the value of the tags 3 and 5 in the block 4
+     * of an MT021 or MT096, acceptable where the block identifier is expected.
+     *
+     * @param s               the block content, with or without the enclosing braces and the block identifier
+     * @param blockIdentifier the block identifier, for example '3' or '5'
+     * @return the block content prefixed by the block identifier
+     */
+    private static String withBlockIdentifier(final String s, final char blockIdentifier) {
+        final String prefix = blockIdentifier + ":";
+        if (s.startsWith(prefix) || s.startsWith("{" + prefix)) {
+            return s;
+        }
+        return prefix + s;
     }
 
     /**
@@ -526,6 +571,38 @@ public class SwiftParser {
     }
 
     /**
+     * Finds the end of a tag within a tag list block content.
+     *
+     * <p>For the tag names in {@link #NESTED_BLOCK_TAG_NAMES} the closing brace is located balancing the
+     * intermediate curly braces, so that the nested blocks are preserved in the tag value. For any other tag name
+     * the first closing brace ends the tag.
+     *
+     * @param data  the tag list block content, without the block identifier
+     * @param start the position of the tag name, meaning right after the tag opening brace
+     * @return the position of the tag closing brace, or -1 if the tag is not closed
+     */
+    private int findEndOfTagInTagListBlock(final String data, final int start) {
+        final int separator = data.indexOf(':', start);
+        if (separator >= 0 && NESTED_BLOCK_TAG_NAMES.contains(data.substring(start, separator))) {
+            int balance = 0;
+            for (int i = start; i < data.length(); i++) {
+                final char c = data.charAt(i);
+                if (c == '{') {
+                    balance++;
+                } else if (c == '}') {
+                    if (balance == 0) {
+                        return i;
+                    }
+                    balance--;
+                }
+            }
+            // the tag is not closed, same as for any other tag it is left for the caller to discard
+            return -1;
+        }
+        return data.indexOf('}', start);
+    }
+
+    /**
      * consumes a tag list block (i.e: block 3, block 5 or user defined block)
      *
      * @param b the block to set up tags into
@@ -547,8 +624,8 @@ public class SwiftParser {
             for (int i = 0; i < data.length(); i++) {
                 final char c = data.charAt(i);
                 if (c == '{') {
-                    final int end = data.indexOf('}', i);
-                    if (end >= 0 && data.length() > end) {
+                    final int end = findEndOfTagInTagListBlock(data, i + 1);
+                    if (end >= 0) {
 
                         final String inner = data.substring(i + 1, end);
                         // Seek the cursor to last 'processed' position

--- a/src/main/java/com/prowidesoftware/swift/io/parser/SwiftParser.java
+++ b/src/main/java/com/prowidesoftware/swift/io/parser/SwiftParser.java
@@ -21,9 +21,6 @@ import com.prowidesoftware.swift.utils.Lib;
 import java.io.*;
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Collections;
-import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 import org.apache.commons.lang3.StringUtils;
@@ -60,8 +57,13 @@ public class SwiftParser {
      * <p>Any other tag keeps the historical reading, ending at the first closing brace. This is relevant for
      * malformed content such as a service message error code that is not properly closed before the next field.
      */
-    private static final Set<String> NESTED_BLOCK_TAG_NAMES =
-            Collections.unmodifiableSet(new HashSet<>(Arrays.asList("1", "2", "3", "4", "5", "270")));
+    private static final Set<String> NESTED_BLOCK_TAG_NAMES = Set.of("1", "2", "3", "4", "5", "270");
+
+    /**
+     * The only nested block that is a text block, and therefore ends at its end of block mark instead of at a
+     * balanced closing brace.
+     */
+    private static final String NESTED_TEXT_BLOCK_TAG_NAME = "4";
 
     /**
      * Errors found while parsing the message.
@@ -182,8 +184,9 @@ public class SwiftParser {
      *
      * @param s block content starting with "{3:" and ending with "}", or the block tags alone, without the block
      *          identifier, as they are found nested in the block 4 of an MT021 or MT096
-     * @return content parsed into a block 3 or an empty block 3 if string cannot be parsed
+     * @return content parsed into a block 3 or an empty block 3 if string cannot be parsed, also for a null content
      * @since 7.8.6
+     * @since 10.3.20 the content is also accepted without the block identifier
      */
     public static SwiftBlock3 parseBlock3(String s) {
         SwiftBlock3 b3 = new SwiftBlock3();
@@ -196,8 +199,9 @@ public class SwiftParser {
      *
      * @param s block content starting with "{5:" and ending with "}", or the block tags alone, without the block
      *          identifier, as they are found nested in the block 4 of an MT021 or MT096
-     * @return content parsed into a block 5 or an empty block 5 if string cannot be parsed
+     * @return content parsed into a block 5 or an empty block 5 if string cannot be parsed, also for a null content
      * @since 7.8.6
+     * @since 10.3.20 the content is also accepted without the block identifier
      */
     public static SwiftBlock5 parseBlock5(String s) {
         SwiftBlock5 b5 = new SwiftBlock5();
@@ -212,13 +216,23 @@ public class SwiftParser {
      * <p>This makes the block content of a nested block, as returned by the value of the tags 3 and 5 in the block 4
      * of an MT021 or MT096, acceptable where the block identifier is expected.
      *
-     * @param s               the block content, with or without the enclosing braces and the block identifier
+     * <p>The enclosing braces of the block identifier form are removed, so that the closing brace is not left
+     * behind as an unparsed text of the block.
+     *
+     * @param s               the block content, with or without the enclosing braces and the block identifier, may
+     *                        be null
      * @param blockIdentifier the block identifier, for example '3' or '5'
-     * @return the block content prefixed by the block identifier
+     * @return the block content prefixed by the block identifier, or just the identifier if the content is null
      */
     private static String withBlockIdentifier(final String s, final char blockIdentifier) {
         final String prefix = blockIdentifier + ":";
-        if (s.startsWith(prefix) || s.startsWith("{" + prefix)) {
+        if (s == null) {
+            return prefix;
+        }
+        if (s.startsWith("{" + prefix)) {
+            return s.endsWith("}") ? s.substring(1, s.length() - 1) : s.substring(1);
+        }
+        if (s.startsWith(prefix)) {
             return s;
         }
         return prefix + s;
@@ -571,11 +585,63 @@ public class SwiftParser {
     }
 
     /**
+     * Finds the end of a nested text block 4, meaning the closing brace of its "[LF]-}" end of block mark.
+     *
+     * <p>A "-}" sequence that is not preceded by a line feed is part of the text and the search continues after it.
+     *
+     * @param data  the tag list block content, without the block identifier
+     * @param start the position to start the analysis at
+     * @return the position of the closing brace, or -1 if the end of block mark is not present
+     */
+    private int findEndOfNestedTextBlock(final String data, final int start) {
+        int mark = data.indexOf("-}", start);
+        while (mark > start) {
+            if (data.charAt(mark - 1) == '\n') {
+                return mark + 1;
+            }
+            mark = data.indexOf("-}", mark + 1);
+        }
+        return -1;
+    }
+
+    /**
+     * Finds the closing brace of a nested block within a tag list block content, balancing the intermediate curly
+     * braces so that the inner blocks are preserved.
+     *
+     * <p>Unlike {@link #findEndOfTagByBraces(String, int)} this returns the position <b>of</b> the closing brace, and
+     * -1 when the content is not balanced.
+     *
+     * @param data  the tag list block content, without the block identifier
+     * @param start the position of the tag name, meaning right after the tag opening brace
+     * @return the position of the closing brace, or -1 if the braces are not balanced
+     * @see #findEndOfTagByBraces(String, int)
+     */
+    private int findEndOfNestedBlockByBraces(final String data, final int start) {
+        int balance = 0;
+        for (int i = start; i < data.length(); i++) {
+            final char c = data.charAt(i);
+            if (c == '{') {
+                balance++;
+            } else if (c == '}') {
+                if (balance == 0) {
+                    return i;
+                }
+                balance--;
+            }
+        }
+        return -1;
+    }
+
+    /**
      * Finds the end of a tag within a tag list block content.
      *
      * <p>For the tag names in {@link #NESTED_BLOCK_TAG_NAMES} the closing brace is located balancing the
      * intermediate curly braces, so that the nested blocks are preserved in the tag value. For any other tag name
      * the first closing brace ends the tag.
+     *
+     * <p>When a nested block tag is not balanced, meaning the content is malformed or truncated, the historical
+     * reading is used as a fallback. This keeps the outcome for any unbalanced content exactly as it was before the
+     * nested blocks were supported, instead of dropping the tag and letting its inner tags be read as siblings.
      *
      * @param data  the tag list block content, without the block identifier
      * @param start the position of the tag name, meaning right after the tag opening brace
@@ -583,22 +649,27 @@ public class SwiftParser {
      */
     private int findEndOfTagInTagListBlock(final String data, final int start) {
         final int separator = data.indexOf(':', start);
-        if (separator >= 0 && NESTED_BLOCK_TAG_NAMES.contains(data.substring(start, separator))) {
-            int balance = 0;
-            for (int i = start; i < data.length(); i++) {
-                final char c = data.charAt(i);
-                if (c == '{') {
-                    balance++;
-                } else if (c == '}') {
-                    if (balance == 0) {
-                        return i;
-                    }
-                    balance--;
-                }
-            }
-            // the tag is not closed, same as for any other tag it is left for the caller to discard
-            return -1;
+        if (separator < 0) {
+            return data.indexOf('}', start);
         }
+        final String tagName = data.substring(start, separator);
+        if (!NESTED_BLOCK_TAG_NAMES.contains(tagName)) {
+            return data.indexOf('}', start);
+        }
+        if (NESTED_TEXT_BLOCK_TAG_NAME.equals(tagName) && isTextBlock(data.substring(start))) {
+            // a nested block 4 in text mode ends at its end of block mark and not at a balanced closing brace,
+            // because the parser is lenient with curly braces within a text block value. A nested block 4 in
+            // tag mode, as in a copied system message, is balanced as any other nested block
+            final int endOfBlock = findEndOfNestedTextBlock(data, separator);
+            if (endOfBlock >= 0) {
+                return endOfBlock;
+            }
+        }
+        final int endOfNestedBlock = findEndOfNestedBlockByBraces(data, start);
+        if (endOfNestedBlock >= 0) {
+            return endOfNestedBlock;
+        }
+        // the nested block is not balanced, fall back to the reading of any other tag
         return data.indexOf('}', start);
     }
 
@@ -945,9 +1016,13 @@ public class SwiftParser {
      * <p>The function search the string looking for an occurrence of "}", bypassing any balanced intermediate curly
      * braces (could be nested blocks or tags with curly braces boundaries).
      *
+     * <p>Unlike {@link #findEndOfNestedBlockByBraces(String, int)} this returns the position <b>after</b> the
+     * closing brace, and never -1.
+     *
      * @param s     the FIN input text
      * @param start the position to start analysis at
      * @return the position where the tag ends (including the "}")
+     * @see #findEndOfNestedBlockByBraces(String, int)
      */
     private int findEndOfTagByBraces(final String s, int start) {
         // scan until end or end of string

--- a/src/test/java/com/prowidesoftware/swift/io/parser/SwiftParserNestedBlockTest.java
+++ b/src/test/java/com/prowidesoftware/swift/io/parser/SwiftParserNestedBlockTest.java
@@ -1,0 +1,307 @@
+/*
+ * Copyright 2006-2026 Prowide
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.prowidesoftware.swift.io.parser;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.prowidesoftware.swift.model.SwiftBlock4;
+import com.prowidesoftware.swift.model.SwiftMessage;
+import com.prowidesoftware.swift.model.Tag;
+import java.io.IOException;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Test cases for the nested blocks that SWIFT defines inside the tag list block 4 of some system messages.
+ *
+ * <p>The affected messages are MT021 (the retrieved message is conveyed as the block 1, 2, 3 headers, the block 4
+ * text and the block 5 trailers), MT096 (the copied message is conveyed as a complete block 1 to 5 message) and
+ * MT056 (each login attempt in field 270 embeds a block 1 and a block 4).
+ */
+public class SwiftParserNestedBlockTest {
+
+    /**
+     * MT096 FINCopy to Server Destination Message: block 4 is a complete nested message.
+     */
+    private static final String MT096 = "{1:F01OURSGB33AXXX0000000000}"
+            + "{2:O0961625170421ABLRXXXXGXXX00000000001704201625N}"
+            + "{3:{103:CLH}{108:SWIFTBICAXXX0000890}}"
+            + "{4:{1:F01PTY1US33AXXX0000000000}{2:I300PTY2GB33AXXXU3003}{3:{103:ABC}}{4:\r\n"
+            + ":15A:\r\n"
+            + ":20:R317703\r\n"
+            + ":22A:NEWT\r\n"
+            + "-}{5:{CHK:73AC90A7A3F1}{SYS:1309041018SMAIBE22AXXX0246001570}}}";
+
+    /**
+     * MT021 Retrieved Message (Text and History): the retrieved message headers, text and trailers are appended
+     * to the report fields in the same block 4.
+     */
+    private static final String MT021 = "{1:F01VNDZBET2AXXX0000000000}{2:I021DYDYXXXXXXXXN}{4:"
+            + "{202:0002}{203:0002}{280:1047010517VNDZBET2AXXX0026000410Y}{108:PRIORITY 2}{431:01}"
+            + "{281:1156010517VNDZBET2AXXX0027000584Y}"
+            + "{1:F01PTY1US33AXXX0000000000}{2:I300PTY2GB33AXXXU3003}{3:{103:ABC}{108:MUR123}}{4:\r\n"
+            + ":20:REF1\r\n"
+            + "-}{5:{CHK:73AC90A7A3F1}{TNG:}}}";
+
+    /**
+     * MT056 Logical Terminal History Report: every field 270 login attempt embeds a login block and, optionally,
+     * a login result, each one made of a block 1 and a block 4.
+     */
+    private static final String MT056 = "{1:F01VNDZBET2AXXX0000000000}{2:I056DYDYXXXXXXXXN}{4:"
+            + "{202:0001}{203:0001}{305:A}"
+            + "{270:2410231030{1:F01VNDZBET2AXXX0000000000}{4:{110:001}}}"
+            + "{270:2410231045{1:F01VNDZBET2AXXX0000000000}{4:{110:002}{114:1}}}}";
+
+    private static SwiftBlock4 block4(String fin) throws IOException {
+        SwiftBlock4 b4 = SwiftMessage.parse(fin).getBlock4();
+        assertThat(b4).isNotNull();
+        return b4;
+    }
+
+    private static void assertTagNamesAndValues(SwiftBlock4 b4, String... nameValuePairs) {
+        assertThat(b4.size()).isEqualTo(nameValuePairs.length / 2);
+        for (int i = 0; i < nameValuePairs.length; i += 2) {
+            Tag tag = b4.getTag(i / 2);
+            assertThat(tag.getName()).isEqualTo(nameValuePairs[i]);
+            assertThat(tag.getValue()).isEqualTo(nameValuePairs[i + 1]);
+        }
+    }
+
+    @Nested
+    @DisplayName("MT096 - FINCopy nested message")
+    class Mt096 {
+
+        @Test
+        void nestedBlocksAreParsedAsSingleTags() throws IOException {
+            assertTagNamesAndValues(
+                    block4(MT096),
+                    "1",
+                    "F01PTY1US33AXXX0000000000",
+                    "2",
+                    "I300PTY2GB33AXXXU3003",
+                    "3",
+                    "{103:ABC}",
+                    "4",
+                    "\r\n:15A:\r\n:20:R317703\r\n:22A:NEWT\r\n-",
+                    "5",
+                    "{CHK:73AC90A7A3F1}{SYS:1309041018SMAIBE22AXXX0246001570}");
+        }
+
+        @Test
+        void nestedSubBlockTagsDoNotLeakIntoTheBlock4() throws IOException {
+            assertThat(block4(MT096).getTagByName("SYS")).isNull();
+            assertThat(block4(MT096).getTagByName("CHK")).isNull();
+            assertThat(block4(MT096).getTagByName("103")).isNull();
+        }
+
+        @Test
+        void messageIsWrittenBackUnchanged() throws IOException {
+            assertThat(SwiftMessage.parse(MT096).message()).isEqualTo(MT096);
+        }
+
+        @Test
+        void theOuterTrailersAreNotMixedWithTheNestedOnes() throws IOException {
+            String fin = "{1:F01FOOGCC2AAXXX0246000987}"
+                    + "{2:O0961200070901ESASNZYYXXXX00001399900709011201S}"
+                    + "{3:{103:AVP}{108:FOOICC2AA1234456}}"
+                    + "{4:{1:F01FOOICC2AAXXX0123000456}{2:I103RCVRCC2AXXXXU}{3:{103:COP}{108:12345678}}{4:\r\n"
+                    + ":20:TRANSREF\r\n"
+                    + "-}{5:{MRF:070901120000070901FOOICC2AAXXX0123000456}}}"
+                    + "{5:{CHK:017654328DEF}{SYS:1200070901FOOICC2AAXXX01234000456}}";
+
+            SwiftMessage sm = SwiftMessage.parse(fin);
+
+            assertThat(sm.getBlock4().size()).isEqualTo(5);
+            assertThat(sm.getBlock4().getTagValue("5")).isEqualTo("{MRF:070901120000070901FOOICC2AAXXX0123000456}");
+
+            assertThat(sm.getBlock5().size()).isEqualTo(2);
+            assertThat(sm.getBlock5().getTagValue("CHK")).isEqualTo("017654328DEF");
+            assertThat(sm.getBlock5().getTagValue("SYS")).isEqualTo("1200070901FOOICC2AAXXX01234000456");
+            assertThat(sm.getBlock5().getTagByName("MRF")).isNull();
+
+            assertThat(sm.message()).isEqualTo(fin);
+        }
+    }
+
+    @Nested
+    @DisplayName("MT021 - retrieved message")
+    class Mt021 {
+
+        @Test
+        void nestedBlocksAreParsedAsSingleTags() throws IOException {
+            assertTagNamesAndValues(
+                    block4(MT021),
+                    "202",
+                    "0002",
+                    "203",
+                    "0002",
+                    "280",
+                    "1047010517VNDZBET2AXXX0026000410Y",
+                    "108",
+                    "PRIORITY 2",
+                    "431",
+                    "01",
+                    "281",
+                    "1156010517VNDZBET2AXXX0027000584Y",
+                    "1",
+                    "F01PTY1US33AXXX0000000000",
+                    "2",
+                    "I300PTY2GB33AXXXU3003",
+                    "3",
+                    "{103:ABC}{108:MUR123}",
+                    "4",
+                    "\r\n:20:REF1\r\n-",
+                    "5",
+                    "{CHK:73AC90A7A3F1}{TNG:}");
+        }
+
+        @Test
+        void theMurOfTheNestedBlock3DoesNotCollideWithTheReportField108() throws IOException {
+            assertThat(block4(MT021).getTagsByName("108")).hasSize(1);
+            assertThat(block4(MT021).getTagValue("108")).isEqualTo("PRIORITY 2");
+        }
+
+        @Test
+        void messageIsWrittenBackUnchanged() throws IOException {
+            assertThat(SwiftMessage.parse(MT021).message()).isEqualTo(MT021);
+        }
+    }
+
+    @Nested
+    @DisplayName("MT056 - login attempts in field 270")
+    class Mt056 {
+
+        @Test
+        void nestedBlocksAreKeptInTheField270Value() throws IOException {
+            assertTagNamesAndValues(
+                    block4(MT056),
+                    "202",
+                    "0001",
+                    "203",
+                    "0001",
+                    "305",
+                    "A",
+                    "270",
+                    "2410231030{1:F01VNDZBET2AXXX0000000000}{4:{110:001}}",
+                    "270",
+                    "2410231045{1:F01VNDZBET2AXXX0000000000}{4:{110:002}{114:1}}");
+        }
+
+        @Test
+        void nestedSubBlockTagsDoNotLeakIntoTheBlock4() throws IOException {
+            assertThat(block4(MT056).getTagByName("4")).isNull();
+            assertThat(block4(MT056).getTagByName("110")).isNull();
+        }
+
+        @Test
+        void messageIsWrittenBackUnchanged() throws IOException {
+            assertThat(SwiftMessage.parse(MT056).message()).isEqualTo(MT056);
+        }
+    }
+
+    /**
+     * Tag list blocks are only read as nested blocks for the tag names where SWIFT defines them. Everywhere else the
+     * legacy lenient reading is preserved: an unbalanced or unexpected curly brace in a tag value keeps ending the
+     * tag at the first closing brace, as it always did.
+     */
+    @Nested
+    @DisplayName("blocks without nested block definitions are read as before")
+    class NotNestedBlocks {
+
+        @Test
+        void nakErrorCodeSwallowingTheMurIsReadAsBefore() throws IOException {
+            // real world sample where the NAK error code is not closed before the MUR trailer field
+            String nak = "{1:F21FOOGIT2TC36A7846389660}{4:{177:1311221031}{451:1}{405:T28008{108:YSGU19326821AXXX}}";
+            assertTagNamesAndValues(block4(nak), "177", "1311221031", "451", "1", "405", "T28008{108:YSGU19326821AXXX");
+            assertThat(SwiftMessage.parse(nak).message()).isEqualTo(nak);
+        }
+
+        @Test
+        void wellFormedNakIsReadAsBefore() throws IOException {
+            String nak = "{1:F21FOOGIT2TC36A7846389660}{4:{177:1311221031}{451:1}{405:T28008}{108:YSGU19326821AXXX}}";
+            assertTagNamesAndValues(
+                    block4(nak), "177", "1311221031", "451", "1", "405", "T28008", "108", "YSGU19326821AXXX");
+            assertThat(SwiftMessage.parse(nak).message()).isEqualTo(nak);
+        }
+
+        @Test
+        void trailerValueWithACurlyBraceIsReadAsBefore() throws IOException {
+            String fin = "{1:F01AAAAAAAAAXXX0000000000}{2:I103BBBBBBBBXXXXN}{4:\n"
+                    + ":20:X\n"
+                    + "-}{5:{MAC:{12345678}}{CHK:ABC}}";
+            SwiftMessage sm = SwiftMessage.parse(fin);
+            assertThat(sm.getBlock5().getTagValue("MAC")).isEqualTo("{12345678");
+            assertThat(sm.getBlock5().getTagValue("CHK")).isEqualTo("ABC");
+        }
+
+        @Test
+        void ackWithTheOriginalMessageAttachedIsReadAsBefore() throws IOException {
+            String original = "{1:F01AAAAAAAAAXXX0000000000}{2:I103BBBBBBBBXXXXN}{4:\n" + ":20:X\n" + "-}";
+            String ack = "{1:F21AAAAAAAAAXXX0000000000}{4:{177:1003250000}{451:0}}" + original;
+            SwiftMessage sm = SwiftMessage.parse(ack);
+            assertTagNamesAndValues(sm.getBlock4(), "177", "1003250000", "451", "0");
+            assertThat(sm.getUnparsedTextsSize()).isEqualTo(1);
+            assertThat(sm.getUnparsedTexts().getText(0)).isEqualTo(original);
+        }
+
+        @Test
+        void userBlockIsReadAsBefore() throws IOException {
+            String fin =
+                    "{1:F01AAAAAAAAAXXX0000000000}{2:I103BBBBBBBBXXXXN}{4:\r\n" + ":20:X\r\n" + "-}{S:{SAC:}{COP:P}}";
+            SwiftMessage sm = SwiftMessage.parse(fin);
+            assertThat(sm.getUserBlock("S").getTagValue("COP")).isEqualTo("P");
+            assertThat(SwiftMessage.parse(fin).message()).isEqualTo(fin);
+        }
+
+        @Test
+        void unclosedNestedBlockTagIsSkippedAsBefore() throws IOException {
+            // the field 270 opens a login block and the message ends without closing any of them
+            String truncated = "{1:F01VNDZBET2AXXX0000000000}{2:I056DYDYXXXXXXXXN}{4:"
+                    + "{202:0001}{270:2410231030{1:F01VNDZBET2AXXX0000000000";
+            SwiftBlock4 b4 = block4(truncated);
+            assertTagNamesAndValues(b4, "202", "0001");
+        }
+
+        @Test
+        void tagWithoutValueSeparatorIsReadAsBefore() throws IOException {
+            String fin = "{1:F01AAAAAAAAAXXX0000000000}{2:I103BBBBBBBBXXXXN}{3:{ABC}}{4:\r\n" + ":20:X\r\n" + "-}";
+            SwiftMessage sm = SwiftMessage.parse(fin);
+            assertThat(sm.getBlock3().size()).isEqualTo(1);
+            assertThat(sm.getBlock3().getTag(0).getName()).isNull();
+            assertThat(sm.getBlock3().getTag(0).getValue()).isEqualTo("ABC");
+        }
+
+        @Test
+        void unclosedPlainTagIsSkippedAsBefore() throws IOException {
+            String truncated = "{1:F01VNDZBET2AXXX0000000000}{2:I056DYDYXXXXXXXXN}{4:" + "{202:0001}{305:AAAA";
+            SwiftBlock4 b4 = block4(truncated);
+            assertTagNamesAndValues(b4, "202", "0001");
+        }
+
+        @Test
+        void block3IsReadAsBefore() throws IOException {
+            String fin = "{1:F01AAAAAAAAAXXX0000000000}{2:I103BBBBBBBBXXXXN}{3:{108:MUR123}{119:STP}}{4:\r\n"
+                    + ":20:X\r\n"
+                    + "-}";
+            SwiftMessage sm = SwiftMessage.parse(fin);
+            assertThat(sm.getBlock3().size()).isEqualTo(2);
+            assertThat(sm.getBlock3().getTagValue("108")).isEqualTo("MUR123");
+            assertThat(sm.getBlock3().getTagValue("119")).isEqualTo("STP");
+            assertThat(SwiftMessage.parse(fin).message()).isEqualTo(fin);
+        }
+    }
+}

--- a/src/test/java/com/prowidesoftware/swift/io/parser/SwiftParserNestedBlockTest.java
+++ b/src/test/java/com/prowidesoftware/swift/io/parser/SwiftParserNestedBlockTest.java
@@ -16,11 +16,14 @@
 package com.prowidesoftware.swift.io.parser;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.tuple;
 
 import com.prowidesoftware.swift.model.SwiftBlock4;
 import com.prowidesoftware.swift.model.SwiftMessage;
 import com.prowidesoftware.swift.model.Tag;
 import java.io.IOException;
+import java.util.List;
+import org.assertj.core.groups.Tuple;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
@@ -31,6 +34,8 @@ import org.junit.jupiter.api.Test;
  * <p>The affected messages are MT021 (the retrieved message is conveyed as the block 1, 2, 3 headers, the block 4
  * text and the block 5 trailers), MT096 (the copied message is conveyed as a complete block 1 to 5 message) and
  * MT056 (each login attempt in field 270 embeds a block 1 and a block 4).
+ *
+ * @see SwiftParserNestedMessageTest
  */
 public class SwiftParserNestedBlockTest {
 
@@ -72,13 +77,31 @@ public class SwiftParserNestedBlockTest {
         return b4;
     }
 
-    private static void assertTagNamesAndValues(SwiftBlock4 b4, String... nameValuePairs) {
-        assertThat(b4.size()).isEqualTo(nameValuePairs.length / 2);
-        for (int i = 0; i < nameValuePairs.length; i += 2) {
-            Tag tag = b4.getTag(i / 2);
-            assertThat(tag.getName()).isEqualTo(nameValuePairs[i]);
-            assertThat(tag.getValue()).isEqualTo(nameValuePairs[i + 1]);
-        }
+    /**
+     * Wraps the given block 4 content, which is the nested message, in an MT096 header.
+     */
+    private static String mt096(String nested) {
+        return "{1:F01OURSGB33AXXX0000000000}"
+                + "{2:O0961625170421ABLRXXXXGXXX00000000001704201625N}"
+                + "{4:"
+                + nested
+                + "}";
+    }
+
+    /**
+     * Asserts the block contains exactly the expected tags, in order, each one given as a name and value pair.
+     */
+    private static void assertTags(SwiftBlock4 b4, Tuple... expectedNamesAndValues) {
+        assertThat(b4.getTags()).extracting(Tag::getName, Tag::getValue).containsExactly(expectedNamesAndValues);
+    }
+
+    /**
+     * Parses the message keeping the parser instance, to assert on the errors it recorded.
+     */
+    private static List<String> parsingErrors(String fin) throws IOException {
+        SwiftParser parser = new SwiftParser(fin);
+        parser.message();
+        return parser.getErrors();
     }
 
     @Nested
@@ -87,18 +110,13 @@ public class SwiftParserNestedBlockTest {
 
         @Test
         void nestedBlocksAreParsedAsSingleTags() throws IOException {
-            assertTagNamesAndValues(
+            assertTags(
                     block4(MT096),
-                    "1",
-                    "F01PTY1US33AXXX0000000000",
-                    "2",
-                    "I300PTY2GB33AXXXU3003",
-                    "3",
-                    "{103:ABC}",
-                    "4",
-                    "\r\n:15A:\r\n:20:R317703\r\n:22A:NEWT\r\n-",
-                    "5",
-                    "{CHK:73AC90A7A3F1}{SYS:1309041018SMAIBE22AXXX0246001570}");
+                    tuple("1", "F01PTY1US33AXXX0000000000"),
+                    tuple("2", "I300PTY2GB33AXXXU3003"),
+                    tuple("3", "{103:ABC}"),
+                    tuple("4", "\r\n:15A:\r\n:20:R317703\r\n:22A:NEWT\r\n-"),
+                    tuple("5", "{CHK:73AC90A7A3F1}{SYS:1309041018SMAIBE22AXXX0246001570}"));
         }
 
         @Test
@@ -143,30 +161,19 @@ public class SwiftParserNestedBlockTest {
 
         @Test
         void nestedBlocksAreParsedAsSingleTags() throws IOException {
-            assertTagNamesAndValues(
+            assertTags(
                     block4(MT021),
-                    "202",
-                    "0002",
-                    "203",
-                    "0002",
-                    "280",
-                    "1047010517VNDZBET2AXXX0026000410Y",
-                    "108",
-                    "PRIORITY 2",
-                    "431",
-                    "01",
-                    "281",
-                    "1156010517VNDZBET2AXXX0027000584Y",
-                    "1",
-                    "F01PTY1US33AXXX0000000000",
-                    "2",
-                    "I300PTY2GB33AXXXU3003",
-                    "3",
-                    "{103:ABC}{108:MUR123}",
-                    "4",
-                    "\r\n:20:REF1\r\n-",
-                    "5",
-                    "{CHK:73AC90A7A3F1}{TNG:}");
+                    tuple("202", "0002"),
+                    tuple("203", "0002"),
+                    tuple("280", "1047010517VNDZBET2AXXX0026000410Y"),
+                    tuple("108", "PRIORITY 2"),
+                    tuple("431", "01"),
+                    tuple("281", "1156010517VNDZBET2AXXX0027000584Y"),
+                    tuple("1", "F01PTY1US33AXXX0000000000"),
+                    tuple("2", "I300PTY2GB33AXXXU3003"),
+                    tuple("3", "{103:ABC}{108:MUR123}"),
+                    tuple("4", "\r\n:20:REF1\r\n-"),
+                    tuple("5", "{CHK:73AC90A7A3F1}{TNG:}"));
         }
 
         @Test
@@ -187,18 +194,13 @@ public class SwiftParserNestedBlockTest {
 
         @Test
         void nestedBlocksAreKeptInTheField270Value() throws IOException {
-            assertTagNamesAndValues(
+            assertTags(
                     block4(MT056),
-                    "202",
-                    "0001",
-                    "203",
-                    "0001",
-                    "305",
-                    "A",
-                    "270",
-                    "2410231030{1:F01VNDZBET2AXXX0000000000}{4:{110:001}}",
-                    "270",
-                    "2410231045{1:F01VNDZBET2AXXX0000000000}{4:{110:002}{114:1}}");
+                    tuple("202", "0001"),
+                    tuple("203", "0001"),
+                    tuple("305", "A"),
+                    tuple("270", "2410231030{1:F01VNDZBET2AXXX0000000000}{4:{110:001}}"),
+                    tuple("270", "2410231045{1:F01VNDZBET2AXXX0000000000}{4:{110:002}{114:1}}"));
         }
 
         @Test
@@ -210,6 +212,22 @@ public class SwiftParserNestedBlockTest {
         @Test
         void messageIsWrittenBackUnchanged() throws IOException {
             assertThat(SwiftMessage.parse(MT056).message()).isEqualTo(MT056);
+        }
+
+        @Test
+        @DisplayName("a login attempt with both a login block and a login result is kept whole")
+        void loginAttemptWithLoginResult() throws IOException {
+            String loginAttempt = "2410231030{1:F01VNDZBET2AXXX0000000000}{4:{110:001}}"
+                    + "{1:F01VNDZBET2AXXX0000000000}{4:{110:002}}";
+            String fin = "{1:F01VNDZBET2AXXX0000000000}{2:I056DYDYXXXXXXXXN}{4:" + "{202:0001}{203:0001}{305:A}{270:"
+                    + loginAttempt + "}}";
+            assertTags(
+                    block4(fin),
+                    tuple("202", "0001"),
+                    tuple("203", "0001"),
+                    tuple("305", "A"),
+                    tuple("270", loginAttempt));
+            assertThat(SwiftMessage.parse(fin).message()).isEqualTo(fin);
         }
     }
 
@@ -226,15 +244,23 @@ public class SwiftParserNestedBlockTest {
         void nakErrorCodeSwallowingTheMurIsReadAsBefore() throws IOException {
             // real world sample where the NAK error code is not closed before the MUR trailer field
             String nak = "{1:F21FOOGIT2TC36A7846389660}{4:{177:1311221031}{451:1}{405:T28008{108:YSGU19326821AXXX}}";
-            assertTagNamesAndValues(block4(nak), "177", "1311221031", "451", "1", "405", "T28008{108:YSGU19326821AXXX");
+            assertTags(
+                    block4(nak),
+                    tuple("177", "1311221031"),
+                    tuple("451", "1"),
+                    tuple("405", "T28008{108:YSGU19326821AXXX"));
             assertThat(SwiftMessage.parse(nak).message()).isEqualTo(nak);
         }
 
         @Test
         void wellFormedNakIsReadAsBefore() throws IOException {
             String nak = "{1:F21FOOGIT2TC36A7846389660}{4:{177:1311221031}{451:1}{405:T28008}{108:YSGU19326821AXXX}}";
-            assertTagNamesAndValues(
-                    block4(nak), "177", "1311221031", "451", "1", "405", "T28008", "108", "YSGU19326821AXXX");
+            assertTags(
+                    block4(nak),
+                    tuple("177", "1311221031"),
+                    tuple("451", "1"),
+                    tuple("405", "T28008"),
+                    tuple("108", "YSGU19326821AXXX"));
             assertThat(SwiftMessage.parse(nak).message()).isEqualTo(nak);
         }
 
@@ -253,7 +279,7 @@ public class SwiftParserNestedBlockTest {
             String original = "{1:F01AAAAAAAAAXXX0000000000}{2:I103BBBBBBBBXXXXN}{4:\n" + ":20:X\n" + "-}";
             String ack = "{1:F21AAAAAAAAAXXX0000000000}{4:{177:1003250000}{451:0}}" + original;
             SwiftMessage sm = SwiftMessage.parse(ack);
-            assertTagNamesAndValues(sm.getBlock4(), "177", "1003250000", "451", "0");
+            assertTags(sm.getBlock4(), tuple("177", "1003250000"), tuple("451", "0"));
             assertThat(sm.getUnparsedTextsSize()).isEqualTo(1);
             assertThat(sm.getUnparsedTexts().getText(0)).isEqualTo(original);
         }
@@ -265,15 +291,6 @@ public class SwiftParserNestedBlockTest {
             SwiftMessage sm = SwiftMessage.parse(fin);
             assertThat(sm.getUserBlock("S").getTagValue("COP")).isEqualTo("P");
             assertThat(SwiftMessage.parse(fin).message()).isEqualTo(fin);
-        }
-
-        @Test
-        void unclosedNestedBlockTagIsSkippedAsBefore() throws IOException {
-            // the field 270 opens a login block and the message ends without closing any of them
-            String truncated = "{1:F01VNDZBET2AXXX0000000000}{2:I056DYDYXXXXXXXXN}{4:"
-                    + "{202:0001}{270:2410231030{1:F01VNDZBET2AXXX0000000000";
-            SwiftBlock4 b4 = block4(truncated);
-            assertTagNamesAndValues(b4, "202", "0001");
         }
 
         @Test
@@ -289,7 +306,7 @@ public class SwiftParserNestedBlockTest {
         void unclosedPlainTagIsSkippedAsBefore() throws IOException {
             String truncated = "{1:F01VNDZBET2AXXX0000000000}{2:I056DYDYXXXXXXXXN}{4:" + "{202:0001}{305:AAAA";
             SwiftBlock4 b4 = block4(truncated);
-            assertTagNamesAndValues(b4, "202", "0001");
+            assertTags(b4, tuple("202", "0001"));
         }
 
         @Test
@@ -302,6 +319,270 @@ public class SwiftParserNestedBlockTest {
             assertThat(sm.getBlock3().getTagValue("108")).isEqualTo("MUR123");
             assertThat(sm.getBlock3().getTagValue("119")).isEqualTo("STP");
             assertThat(SwiftMessage.parse(fin).message()).isEqualTo(fin);
+        }
+
+        @Test
+        @DisplayName("the nested block tag names are matched exactly, not by prefix")
+        void tagNamesCloseToTheNestedBlockOnesAreReadAsBefore() throws IOException {
+            String fin =
+                    "{1:F01VNDZBET2AXXX0000000000}{2:I056DYDYXXXXXXXXN}{4:" + "{27:A{Y:1}}{45:B{Y:2}}{2701:C{Y:3}}}";
+            assertTags(block4(fin), tuple("27", "A{Y:1"), tuple("45", "B{Y:2"), tuple("2701", "C{Y:3"));
+        }
+
+        @Test
+        @DisplayName("a tag with an empty name is not read as a nested block")
+        void tagWithAnEmptyNameIsReadAsBefore() throws IOException {
+            String fin = "{1:F01VNDZBET2AXXX0000000000}{2:I056DYDYXXXXXXXXN}{4:" + "{202:0001}{:A{Y:1}}}";
+            SwiftBlock4 b4 = block4(fin);
+            assertThat(b4.getTagValue("202")).isEqualTo("0001");
+            assertThat(b4.getTag(1).getValue()).isEqualTo("A{Y:1");
+        }
+    }
+
+    /**
+     * Well formed variations of the nested blocks, beyond the plain MT021, MT056 and MT096 samples.
+     */
+    @Nested
+    @DisplayName("nested block variations")
+    class Variations {
+
+        /**
+         * The block 4 of the MT096 copied message, which is itself a complete MT103, as it travels nested within the
+         * retrieved message of an MT021.
+         */
+        private static final String MT096_BLOCK_4 = "{1:F01PTY1US33AXXX0000000000}{2:I103PTY2GB33AXXXN}{4:\r\n"
+                + ":20:REF103\r\n"
+                + "-}{5:{CHK:AAAAAAAAAAAA}}";
+
+        @Test
+        @DisplayName("a retrieved message that is itself a FINCopy nests three levels deep")
+        void threeLevelsOfNesting() throws IOException {
+            // an MT021 whose retrieved message is an MT096, whose copied message is an MT103
+            String fin = "{1:F01VNDZBET2AXXX0000000000}{2:I021DYDYXXXXXXXXN}{4:"
+                    + "{202:0001}{203:0001}"
+                    + "{1:F01OURSGB33AXXX0000000000}"
+                    + "{2:O0961625170421ABLRXXXXGXXX00000000001704201625N}"
+                    + "{4:"
+                    + MT096_BLOCK_4
+                    + "}"
+                    + "{5:{CHK:BBBBBBBBBBBB}}}";
+
+            assertTags(
+                    block4(fin),
+                    tuple("202", "0001"),
+                    tuple("203", "0001"),
+                    tuple("1", "F01OURSGB33AXXX0000000000"),
+                    tuple("2", "O0961625170421ABLRXXXXGXXX00000000001704201625N"),
+                    tuple("4", MT096_BLOCK_4),
+                    tuple("5", "{CHK:BBBBBBBBBBBB}"));
+            assertThat(SwiftMessage.parse(fin).message()).isEqualTo(fin);
+        }
+
+        @Test
+        @DisplayName("the optional nested block 3 may be absent")
+        void copiedMessageWithoutBlock3() throws IOException {
+            String fin = mt096("{1:F01PTY1US33AXXX0000000000}{2:I199PTY2GB33AXXXU3003}{4:\r\n"
+                    + ":20:X\r\n"
+                    + "-}{5:{CHK:73AC90A7A3F1}}");
+            assertTags(
+                    block4(fin),
+                    tuple("1", "F01PTY1US33AXXX0000000000"),
+                    tuple("2", "I199PTY2GB33AXXXU3003"),
+                    tuple("4", "\r\n:20:X\r\n-"),
+                    tuple("5", "{CHK:73AC90A7A3F1}"));
+            assertThat(SwiftMessage.parse(fin).message()).isEqualTo(fin);
+        }
+
+        @Test
+        @DisplayName("the optional nested block 5 may be absent")
+        void copiedMessageWithoutBlock5() throws IOException {
+            String fin = mt096(
+                    "{1:F01PTY1US33AXXX0000000000}{2:I199PTY2GB33AXXXU3003}{3:{103:ABC}}{4:\r\n" + ":20:X\r\n" + "-}");
+            assertTags(
+                    block4(fin),
+                    tuple("1", "F01PTY1US33AXXX0000000000"),
+                    tuple("2", "I199PTY2GB33AXXXU3003"),
+                    tuple("3", "{103:ABC}"),
+                    tuple("4", "\r\n:20:X\r\n-"));
+            assertThat(SwiftMessage.parse(fin).message()).isEqualTo(fin);
+        }
+
+        @Test
+        @DisplayName("an empty nested block is read as a tag without value, and written back unchanged")
+        void emptyNestedBlock3() throws IOException {
+            String fin = mt096("{1:F01PTY1US33AXXX0000000000}{3:}{4:\r\n" + ":20:X\r\n" + "-}");
+            SwiftBlock4 b4 = block4(fin);
+            assertThat(b4.size()).isEqualTo(3);
+            assertThat(b4.getTagByName("3")).isNotNull();
+            // Tag(String) leaves the value null when there is nothing after the separator
+            assertThat(b4.getTagValue("3")).isNull();
+            assertThat(SwiftMessage.parse(fin).message()).isEqualTo(fin);
+        }
+
+        @Test
+        @DisplayName("a nested block 5 with several trailers is kept whole")
+        void nestedBlock5WithSeveralTrailers() throws IOException {
+            String fin = mt096("{1:F01PTY1US33AXXX0000000000}{4:\r\n"
+                    + ":20:X\r\n"
+                    + "-}{5:{CHK:73AC90A7A3F1}{SYS:1309041018SMAIBE22AXXX0246001570}{TNG:}}");
+            assertThat(block4(fin).getTagValue("5"))
+                    .isEqualTo("{CHK:73AC90A7A3F1}{SYS:1309041018SMAIBE22AXXX0246001570}{TNG:}");
+            assertThat(SwiftMessage.parse(fin).message()).isEqualTo(fin);
+        }
+
+        @Test
+        @DisplayName("a nested block 4 in tag mode is balanced instead of ending at an end of block mark")
+        void copiedSystemMessageHasATagModeBlock4() throws IOException {
+            String fin = mt096("{1:F01PTY1US33AXXX0000000000}{2:O0111625170421ABLRXXXXGXXX00000000001704201625N}"
+                    + "{4:{177:1003250000}{451:0}}{5:{CHK:73AC90A7A3F1}}");
+            assertTags(
+                    block4(fin),
+                    tuple("1", "F01PTY1US33AXXX0000000000"),
+                    tuple("2", "O0111625170421ABLRXXXXGXXX00000000001704201625N"),
+                    tuple("4", "{177:1003250000}{451:0}"),
+                    tuple("5", "{CHK:73AC90A7A3F1}"));
+            assertThat(SwiftMessage.parse(fin).message()).isEqualTo(fin);
+        }
+
+        @Test
+        @DisplayName("an end of block sequence within the nested text is not mistaken for the end of the block")
+        void endOfBlockSequenceInsideTheNestedText() throws IOException {
+            // the first "-}" does not follow a line break, so it is part of the narrative and the search for the end
+            // of block mark continues after it
+            String fin =
+                    mt096("{1:F01PTY1US33AXXX0000000000}{4:\r\n" + ":79:NARRATIVE X{Y-}Z\r\n" + "-}{5:{CHK:73AC90A7}}");
+            assertTags(
+                    block4(fin),
+                    tuple("1", "F01PTY1US33AXXX0000000000"),
+                    tuple("4", "\r\n:79:NARRATIVE X{Y-}Z\r\n-"),
+                    tuple("5", "{CHK:73AC90A7}"));
+            assertThat(SwiftMessage.parse(fin).message()).isEqualTo(fin);
+        }
+
+        @Test
+        @DisplayName("an unmatched opening brace in the nested text does not swallow the following blocks")
+        void unmatchedOpeningBraceInTheNestedText() throws IOException {
+            // the parser is lenient with curly braces in a text block value, see
+            // SwiftParserParseBlockTest#testGetBlock4Brackets1
+            String fin = "{1:F01OURSGB33AXXX0000000000}"
+                    + "{2:O0961625170421ABLRXXXXGXXX00000000001704201625N}"
+                    + "{4:{1:F01PTY1US33AXXX0000000000}{2:I199PTY2GB33AXXXU3003}{4:\r\n"
+                    + ":79:foobar{bad\r\n"
+                    + "-}{5:{CHK:73AC90A7A3F1}}}";
+
+            assertTags(
+                    block4(fin),
+                    tuple("1", "F01PTY1US33AXXX0000000000"),
+                    tuple("2", "I199PTY2GB33AXXXU3003"),
+                    tuple("4", "\r\n:79:foobar{bad\r\n-"),
+                    tuple("5", "{CHK:73AC90A7A3F1}"));
+
+            // the braces of the sample are unbalanced by one, so the reader reaches the end of the input looking for
+            // the closing brace of the block 4 and reports it. The message is therefore not written back unchanged
+            assertThat(parsingErrors(fin)).containsExactly("Missing or invalid closing bracket in block 4");
+        }
+    }
+
+    /**
+     * Malformed or truncated nesting. The parser is lenient with these, the point of the assertions below is to pin
+     * the outcome down so that any future change to the nested block reading is a deliberate one.
+     */
+    @Nested
+    @DisplayName("malformed nesting")
+    class MalformedNesting {
+
+        @Test
+        @DisplayName("an unclosed nested block tag does not leak its sub-tags into the enclosing block")
+        void unclosedNestedBlockTagFallsBackToTheHistoricalReading() throws IOException {
+            // the nested block 5 is opened and the message ends before it is closed, so the tag is read as any other
+            // tag, ending at the first closing brace, instead of dropping the tag and reading CHK as a sibling
+            String truncated = "{1:F01AAAAAAAAAXXX0000000000}{4:{1:AAA}{5:{CHK:X}";
+            SwiftBlock4 b4 = block4(truncated);
+            assertTags(b4, tuple("1", "AAA"), tuple("5", "{CHK:X"));
+            assertThat(b4.getTagByName("CHK")).isNull();
+            assertThat(b4.getUnparsedTextsSize()).isZero();
+        }
+
+        @Test
+        @DisplayName("an unclosed nested block tag with nothing left to read is skipped as before")
+        void unclosedNestedBlockTagIsSkippedAsBefore() throws IOException {
+            // the field 270 opens a login block and the message ends without closing any of them, there is no closing
+            // brace left for the fallback reading either, so the tag is discarded
+            String truncated = "{1:F01VNDZBET2AXXX0000000000}{2:I056DYDYXXXXXXXXN}{4:"
+                    + "{202:0001}{270:2410231030{1:F01VNDZBET2AXXX0000000000";
+            SwiftBlock4 b4 = block4(truncated);
+            assertTags(b4, tuple("202", "0001"));
+        }
+
+        @Test
+        @DisplayName("an unbalanced sub-tag makes a nested tag mode block 4 swallow the nested block 5")
+        void unbalancedSubTagInANestedTagModeBlock4() throws IOException {
+            // an MT096 copying the malformed NAK of NotNestedBlocks#nakErrorCodeSwallowingTheMurIsReadAsBefore: the
+            // error code 405 is never closed, so the nested block 4 is only balanced by the closing brace of the
+            // nested block 5 and takes it in
+            String fin = mt096("{4:{405:T28008{108:X}}{5:{CHK:A}}");
+            assertTags(block4(fin), tuple("4", "{405:T28008{108:X}}{5:{CHK:A}}"));
+            assertThat(parsingErrors(fin)).containsExactly("Missing or invalid closing bracket in block 4");
+        }
+
+        @Test
+        @DisplayName("two nested text blocks 4 merge when the first one has no end of block mark")
+        void twoNestedTextBlocks4WhenTheFirstHasNoEndOfBlockMark() throws IOException {
+            // a nested message has a single block 4, so this cannot be a well formed sample. The first block 4 ends
+            // with a plain closing brace, so the end of block mark that closes the second one is taken as its own
+            String fin = mt096("{4:\r\n" + ":20:X\r\n" + "}{4:\r\n" + ":20:Y\r\n" + "-}");
+            assertTags(block4(fin), tuple("4", "\r\n:20:X\r\n}{4:\r\n:20:Y\r\n-"));
+            // the content is preserved, so the message is still written back unchanged
+            assertThat(SwiftMessage.parse(fin).message()).isEqualTo(fin);
+        }
+
+        @Test
+        @DisplayName("an end of block sequence in the nested text truncates the enclosing block 4")
+        void endOfBlockSequenceInsideTheNestedTextWithoutCurlyBraces() throws IOException {
+            // the "-}" of the narrative closes the enclosing block 4 before the tag reading even starts, because the
+            // block content is delimited by the block reader and not by the nested block tag values. The nested
+            // trailers therefore end up as the trailers of the enclosing message. This is a pre-existing limitation
+            // of the block reader, unrelated to the nested block tag values, kept here to document it
+            String fin =
+                    mt096("{1:F01PTY1US33AXXX0000000000}{4:\r\n" + ":79:NARRATIVE XY-}Z\r\n" + "-}{5:{CHK:73AC90A7}}");
+            SwiftMessage sm = SwiftMessage.parse(fin);
+            assertTags(sm.getBlock4(), tuple("1", "F01PTY1US33AXXX0000000000"), tuple("4", "\r\n:79:NARRATIVE XY-"));
+            assertThat(sm.getBlock5().getTagValue("CHK")).isEqualTo("73AC90A7");
+            assertThat(sm.message()).isNotEqualTo(fin);
+        }
+    }
+
+    @Nested
+    @DisplayName("single block parse of a nested block content")
+    class SingleBlockParse {
+
+        @Test
+        @DisplayName("parseBlock3 prepends the identifier to content that merely starts with the same digit")
+        void parseBlock3WithContentStartingWithTheSameDigit() {
+            assertThat(SwiftParser.parseBlock3("{308:X}").getTagValue("308")).isEqualTo("X");
+        }
+
+        @Test
+        @DisplayName("parseBlock5 keeps the legacy reading for a trailer value with a curly brace")
+        void parseBlock5WithACurlyBraceInTheValue() {
+            assertThat(SwiftParser.parseBlock5("{MAC:{12345678}}").getTagValue("MAC"))
+                    .isEqualTo("{12345678");
+        }
+
+        @Test
+        @DisplayName("the block identifier form does not leave the closing brace as an unparsed text")
+        void identifierFormLeavesNoUnparsedText() {
+            assertThat(SwiftParser.parseBlock3("{3:{103:CLH}{108:MUR123}}").getUnparsedTextsSize())
+                    .isZero();
+            assertThat(SwiftParser.parseBlock5("{5:{CHK:73AC90A7A3F1}}").getUnparsedTextsSize())
+                    .isZero();
+        }
+
+        @Test
+        @DisplayName("a null content returns an empty block instead of failing")
+        void nullContentReturnsAnEmptyBlock() {
+            assertThat(SwiftParser.parseBlock3(null).isEmpty()).isTrue();
+            assertThat(SwiftParser.parseBlock5(null).isEmpty()).isTrue();
         }
     }
 }

--- a/src/test/java/com/prowidesoftware/swift/io/parser/SwiftParserNestedMessageTest.java
+++ b/src/test/java/com/prowidesoftware/swift/io/parser/SwiftParserNestedMessageTest.java
@@ -1,0 +1,135 @@
+/*
+ * Copyright 2006-2026 Prowide
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.prowidesoftware.swift.io.parser;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.prowidesoftware.swift.model.SwiftBlock4;
+import com.prowidesoftware.swift.model.SwiftMessage;
+import java.io.IOException;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Test cases for rebuilding the message that travels nested in the block 4 of an MT021, MT056 or MT096, out of the
+ * nested block tags and the single block parse methods in {@link SwiftParser}.
+ */
+public class SwiftParserNestedMessageTest {
+
+    /**
+     * Rebuilds a message out of the nested block tags of a tag list block 4.
+     */
+    private static SwiftMessage nestedMessage(SwiftBlock4 block4) {
+        SwiftMessage nested = new SwiftMessage();
+        if (block4.getTagByNumber(1) != null) {
+            nested.addBlock(SwiftParser.parseBlock1(block4.getTagByNumber(1).getValue()));
+        }
+        if (block4.getTagByNumber(2) != null) {
+            nested.addBlock(SwiftParser.parseBlock2(block4.getTagByNumber(2).getValue()));
+        }
+        if (block4.getTagByNumber(3) != null) {
+            nested.addBlock(SwiftParser.parseBlock3(block4.getTagByNumber(3).getValue()));
+        }
+        if (block4.getTagByNumber(4) != null) {
+            nested.addBlock(SwiftParser.parseBlock4(block4.getTagByNumber(4).getValue()));
+        }
+        if (block4.getTagByNumber(5) != null) {
+            nested.addBlock(SwiftParser.parseBlock5(block4.getTagByNumber(5).getValue()));
+        }
+        return nested;
+    }
+
+    @Test
+    void mt096CopiedMessageIsRebuiltFromTheNestedBlockTags() throws IOException {
+        String fin = "{1:F01OURSGB33AXXX0000000000}"
+                + "{2:O0961625170421ABLRXXXXGXXX00000000001704201625N}"
+                + "{3:{103:CLH}{108:SWIFTBICAXXX0000890}}"
+                + "{4:{1:F01PTY1US33AXXX0000000000}{2:I300PTY2GB33AXXXU3003}{3:{103:ABC}{108:MUR123}}{4:\r\n"
+                + ":15A:\r\n"
+                + ":20:R317703\r\n"
+                + ":22A:NEWT\r\n"
+                + "-}{5:{CHK:73AC90A7A3F1}{SYS:1309041018SMAIBE22AXXX0246001570}}}";
+
+        SwiftMessage mt096 = SwiftMessage.parse(fin);
+        assertThat(mt096.isType(96)).isTrue();
+
+        SwiftMessage copied = nestedMessage(mt096.getBlock4());
+
+        assertThat(copied.getBlock1()).isNotNull();
+        assertThat(copied.getBlock1().getLogicalTerminal()).isEqualTo("PTY1US33AXXX");
+
+        assertThat(copied.getBlock2()).isNotNull();
+        assertThat(copied.getType()).isEqualTo("300");
+        assertThat(copied.getBlock2().isInput()).isTrue();
+
+        assertThat(copied.getBlock3()).isNotNull();
+        assertThat(copied.getBlock3().size()).isEqualTo(2);
+        assertThat(copied.getBlock3().getTagValue("103")).isEqualTo("ABC");
+        assertThat(copied.getBlock3().getTagValue("108")).isEqualTo("MUR123");
+
+        assertThat(copied.getBlock4()).isNotNull();
+        assertThat(copied.getBlock4().size()).isEqualTo(3);
+        assertThat(copied.getBlock4().getTagValue("15A")).isEmpty();
+        assertThat(copied.getBlock4().getTagValue("20")).isEqualTo("R317703");
+        assertThat(copied.getBlock4().getTagValue("22A")).isEqualTo("NEWT");
+
+        assertThat(copied.getBlock5()).isNotNull();
+        assertThat(copied.getBlock5().size()).isEqualTo(2);
+        assertThat(copied.getBlock5().getTagValue("CHK")).isEqualTo("73AC90A7A3F1");
+        assertThat(copied.getBlock5().getTagValue("SYS")).isEqualTo("1309041018SMAIBE22AXXX0246001570");
+    }
+
+    @Test
+    void mt021RetrievedMessageIsRebuiltFromTheNestedBlockTags() throws IOException {
+        String fin = "{1:F01VNDZBET2AXXX0000000000}{2:I021DYDYXXXXXXXXN}{4:"
+                + "{202:0002}{203:0002}{280:1047010517VNDZBET2AXXX0026000410Y}{108:PRIORITY 2}"
+                + "{1:F01PTY1US33AXXX0000000000}{2:I300PTY2GB33AXXXU3003}{3:{103:ABC}}{4:\r\n"
+                + ":20:REF1\r\n"
+                + "-}{5:{CHK:73AC90A7A3F1}}}";
+
+        SwiftMessage mt021 = SwiftMessage.parse(fin);
+        assertThat(mt021.isType(21)).isTrue();
+
+        SwiftMessage retrieved = nestedMessage(mt021.getBlock4());
+
+        assertThat(retrieved.getBlock1().getLogicalTerminal()).isEqualTo("PTY1US33AXXX");
+        assertThat(retrieved.getType()).isEqualTo("300");
+        assertThat(retrieved.getBlock3().getTagValue("103")).isEqualTo("ABC");
+        assertThat(retrieved.getBlock4().getTagValue("20")).isEqualTo("REF1");
+        assertThat(retrieved.getBlock5().getTagValue("CHK")).isEqualTo("73AC90A7A3F1");
+    }
+
+    @Test
+    void mt056LoginBlockIsRebuiltFromTheField270Value() throws IOException {
+        String fin = "{1:F01VNDZBET2AXXX0000000000}{2:I056DYDYXXXXXXXXN}{4:"
+                + "{202:0001}{203:0001}{305:A}"
+                + "{270:2410231030{1:F01VNDZBET2AXXX0000000000}{4:{110:001}{114:1}}}}";
+
+        SwiftMessage mt056 = SwiftMessage.parse(fin);
+        String loginAttempt = mt056.getBlock4().getTagValue("270");
+        assertThat(loginAttempt).isEqualTo("2410231030{1:F01VNDZBET2AXXX0000000000}{4:{110:001}{114:1}}");
+
+        // the login block is the value after the 10 characters timestamp
+        String loginBlock = loginAttempt.substring(10);
+        SwiftBlock4 asTagList = SwiftParser.parseBlock4(loginBlock.substring(loginBlock.indexOf("{4:")));
+
+        assertThat(SwiftParser.parseBlock1(loginBlock.substring(0, loginBlock.indexOf("}") + 1))
+                        .getLogicalTerminal())
+                .isEqualTo("VNDZBET2AXXX");
+        assertThat(asTagList.size()).isEqualTo(2);
+        assertThat(asTagList.getTagValue("110")).isEqualTo("001");
+        assertThat(asTagList.getTagValue("114")).isEqualTo("1");
+    }
+}

--- a/src/test/java/com/prowidesoftware/swift/io/parser/SwiftParserParseBlockTest.java
+++ b/src/test/java/com/prowidesoftware/swift/io/parser/SwiftParserParseBlockTest.java
@@ -18,9 +18,10 @@ package com.prowidesoftware.swift.io.parser;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 
+import com.prowidesoftware.swift.model.SwiftBlock3;
 import com.prowidesoftware.swift.model.SwiftBlock4;
+import com.prowidesoftware.swift.model.SwiftBlock5;
 import com.prowidesoftware.swift.model.SwiftMessage;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 
 /**
@@ -95,50 +96,111 @@ public class SwiftParserParseBlockTest {
         assertEquals(6, b4.size());
     }
 
+    @Test
+    public void testParseBlock3WithBlockIdentifierAndBrackets() {
+        SwiftBlock3 b3 = SwiftParser.parseBlock3("{3:{103:CLH}{108:MUR123}}");
+        assertEquals(2, b3.size());
+        assertEquals("CLH", b3.getTagValue("103"));
+        assertEquals("MUR123", b3.getTagValue("108"));
+    }
+
+    @Test
+    public void testParseBlock3WithBlockIdentifierWithoutBrackets() {
+        SwiftBlock3 b3 = SwiftParser.parseBlock3("3:{103:CLH}{108:MUR123}");
+        assertEquals(2, b3.size());
+        assertEquals("CLH", b3.getTagValue("103"));
+        assertEquals("MUR123", b3.getTagValue("108"));
+    }
+
+    /**
+     * This is the form of the nested block 3 within the block 4 of an MT021 or MT096, as returned by the tag value
+     */
+    @Test
+    public void testParseBlock3WithoutBlockIdentifier() {
+        SwiftBlock3 b3 = SwiftParser.parseBlock3("{103:CLH}{108:MUR123}");
+        assertEquals(2, b3.size());
+        assertEquals("CLH", b3.getTagValue("103"));
+        assertEquals("MUR123", b3.getTagValue("108"));
+    }
+
+    @Test
+    public void testParseBlock3Empty() {
+        assertEquals(0, SwiftParser.parseBlock3("").size());
+        assertEquals(0, SwiftParser.parseBlock3("{3:}").size());
+        assertEquals(0, SwiftParser.parseBlock3("3:").size());
+    }
+
+    @Test
+    public void testParseBlock5WithBlockIdentifierAndBrackets() {
+        SwiftBlock5 b5 = SwiftParser.parseBlock5("{5:{CHK:73AC90A7A3F1}{SYS:1309041018SMAIBE22AXXX0246001570}}");
+        assertEquals(2, b5.size());
+        assertEquals("73AC90A7A3F1", b5.getTagValue("CHK"));
+        assertEquals("1309041018SMAIBE22AXXX0246001570", b5.getTagValue("SYS"));
+    }
+
+    @Test
+    public void testParseBlock5WithBlockIdentifierWithoutBrackets() {
+        SwiftBlock5 b5 = SwiftParser.parseBlock5("5:{CHK:73AC90A7A3F1}{SYS:1309041018SMAIBE22AXXX0246001570}");
+        assertEquals(2, b5.size());
+        assertEquals("73AC90A7A3F1", b5.getTagValue("CHK"));
+        assertEquals("1309041018SMAIBE22AXXX0246001570", b5.getTagValue("SYS"));
+    }
+
+    /**
+     * This is the form of the nested block 5 within the block 4 of an MT021 or MT096, as returned by the tag value
+     */
+    @Test
+    public void testParseBlock5WithoutBlockIdentifier() {
+        SwiftBlock5 b5 = SwiftParser.parseBlock5("{CHK:73AC90A7A3F1}{SYS:1309041018SMAIBE22AXXX0246001570}");
+        assertEquals(2, b5.size());
+        assertEquals("73AC90A7A3F1", b5.getTagValue("CHK"));
+        assertEquals("1309041018SMAIBE22AXXX0246001570", b5.getTagValue("SYS"));
+    }
+
+    @Test
+    public void testParseBlock5Empty() {
+        assertEquals(0, SwiftParser.parseBlock5("").size());
+        assertEquals(0, SwiftParser.parseBlock5("{5:}").size());
+        assertEquals(0, SwiftParser.parseBlock5("5:").size());
+    }
+
     /**
      * Test parsing nested blocks as tags
+     *
+     * @see SwiftParserNestedBlockTest
+     * @see SwiftParserNestedMessageTest
      */
-    @Disabled
     @Test
     public void testNestedBlocks() throws Exception {
         String fin =
-                "{1:F01OURSGB33AXXX0000000000}{2:O0961625170421ABLRXXXXGXXX00000000001704201625N}{3:{103:CLH}{108:SWIFTBICAXXX0000890}}{4:{1:F01PTY1US33AXXX0000000000}{2:I300PTY2GB33AXXXU3003}{3:{103:ABC}}{4:\n"
-                        + ":15A:\n"
-                        + ":20:R317703\n"
-                        + ":22A:NEWT\n"
+                "{1:F01OURSGB33AXXX0000000000}{2:O0961625170421ABLRXXXXGXXX00000000001704201625N}{3:{103:CLH}{108:SWIFTBICAXXX0000890}}{4:{1:F01PTY1US33AXXX0000000000}{2:I300PTY2GB33AXXXU3003}{3:{103:ABC}}{4:\r\n"
+                        + ":15A:\r\n"
+                        + ":20:R317703\r\n"
+                        + ":22A:NEWT\r\n"
                         + "-}{5:{CHK:73AC90A7A3F1}{SYS:1309041018SMAIBE22AXXX0246001570}}}";
 
-        // parse with SwiftMessage
         SwiftMessage sm = SwiftMessage.parse(fin);
-        if (sm.isType(96)) {
-            SwiftBlock4 nested = sm.getBlock4();
-            SwiftMessage mt = new SwiftMessage();
-            if (nested.getTagByNumber(1) != null) {
-                mt.addBlock(SwiftParser.parseBlock1(nested.getTagByNumber(1).getValue()));
-            }
-            if (nested.getTagByNumber(2) != null) {
-                mt.addBlock(SwiftParser.parseBlock2(nested.getTagByNumber(2).getValue()));
-            }
-            if (nested.getTagByNumber(3) != null) {
-                // System.out.println(nested.getTagByNumber(3).getValue());
-                mt.addBlock(SwiftParser.parseBlock3(nested.getTagByNumber(3).getValue()));
-            }
-            if (nested.getTagByNumber(4) != null) {
-                mt.addBlock(SwiftParser.parseBlock4(nested.getTagByNumber(4).getValue()));
-            }
-            if (nested.getTagByNumber(5) != null) {
-                mt.addBlock(SwiftParser.parseBlock5(nested.getTagByNumber(5).getValue()));
-            }
-            assertNotNull(mt.getBlock1());
-            assertNotNull(mt.getBlock2());
-            assertNotNull(mt.getBlock3());
-            assertNotNull(mt.getBlock4());
-            assertNotNull(mt.getBlock5());
-            assertEquals("F01PTY1US33AXXX0000000000", nested.getTagValue("1"));
-            assertEquals("I300PTY2GB33AXXXU3003", nested.getTagValue("2"));
-            assertEquals("{103:ABC}", nested.getTagValue("3"));
-            assertEquals("\\n" + ":15A:\\n" + ":20:R317703\\n" + ":22A:NEWT\\n" + "-", nested.getTagValue("4"));
-            assertEquals("{CHK:73AC90A7A3F1}{SYS:1309041018SMAIBE22AXXX0246001570}", nested.getTagValue("5"));
-        }
+        assertEquals("096", sm.getType());
+
+        final SwiftBlock4 nested = sm.getBlock4();
+        assertNotNull(nested);
+        assertEquals(5, nested.size());
+        assertEquals("F01PTY1US33AXXX0000000000", nested.getTagValue("1"));
+        assertEquals("I300PTY2GB33AXXXU3003", nested.getTagValue("2"));
+        assertEquals("{103:ABC}", nested.getTagValue("3"));
+        assertEquals("\r\n" + ":15A:\r\n" + ":20:R317703\r\n" + ":22A:NEWT\r\n" + "-", nested.getTagValue("4"));
+        assertEquals("{CHK:73AC90A7A3F1}{SYS:1309041018SMAIBE22AXXX0246001570}", nested.getTagValue("5"));
+
+        SwiftMessage mt = new SwiftMessage();
+        mt.addBlock(SwiftParser.parseBlock1(nested.getTagValue("1")));
+        mt.addBlock(SwiftParser.parseBlock2(nested.getTagValue("2")));
+        mt.addBlock(SwiftParser.parseBlock3(nested.getTagValue("3")));
+        mt.addBlock(SwiftParser.parseBlock4(nested.getTagValue("4")));
+        mt.addBlock(SwiftParser.parseBlock5(nested.getTagValue("5")));
+        assertNotNull(mt.getBlock1());
+        assertNotNull(mt.getBlock2());
+        assertEquals(1, mt.getBlock3().size());
+        assertEquals(3, mt.getBlock4().size());
+        assertEquals(2, mt.getBlock5().size());
     }
 }

--- a/src/test/java/com/prowidesoftware/swift/io/parser/SwiftParserParseBlockTest.java
+++ b/src/test/java/com/prowidesoftware/swift/io/parser/SwiftParserParseBlockTest.java
@@ -21,11 +21,13 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 import com.prowidesoftware.swift.model.SwiftBlock3;
 import com.prowidesoftware.swift.model.SwiftBlock4;
 import com.prowidesoftware.swift.model.SwiftBlock5;
-import com.prowidesoftware.swift.model.SwiftMessage;
 import org.junit.jupiter.api.Test;
 
 /**
  * Test cases for the parseBlock methods in the parser implementation
+ *
+ * @see SwiftParserNestedBlockTest
+ * @see SwiftParserNestedMessageTest
  */
 public class SwiftParserParseBlockTest {
 
@@ -162,45 +164,5 @@ public class SwiftParserParseBlockTest {
         assertEquals(0, SwiftParser.parseBlock5("").size());
         assertEquals(0, SwiftParser.parseBlock5("{5:}").size());
         assertEquals(0, SwiftParser.parseBlock5("5:").size());
-    }
-
-    /**
-     * Test parsing nested blocks as tags
-     *
-     * @see SwiftParserNestedBlockTest
-     * @see SwiftParserNestedMessageTest
-     */
-    @Test
-    public void testNestedBlocks() throws Exception {
-        String fin =
-                "{1:F01OURSGB33AXXX0000000000}{2:O0961625170421ABLRXXXXGXXX00000000001704201625N}{3:{103:CLH}{108:SWIFTBICAXXX0000890}}{4:{1:F01PTY1US33AXXX0000000000}{2:I300PTY2GB33AXXXU3003}{3:{103:ABC}}{4:\r\n"
-                        + ":15A:\r\n"
-                        + ":20:R317703\r\n"
-                        + ":22A:NEWT\r\n"
-                        + "-}{5:{CHK:73AC90A7A3F1}{SYS:1309041018SMAIBE22AXXX0246001570}}}";
-
-        SwiftMessage sm = SwiftMessage.parse(fin);
-        assertEquals("096", sm.getType());
-
-        final SwiftBlock4 nested = sm.getBlock4();
-        assertNotNull(nested);
-        assertEquals(5, nested.size());
-        assertEquals("F01PTY1US33AXXX0000000000", nested.getTagValue("1"));
-        assertEquals("I300PTY2GB33AXXXU3003", nested.getTagValue("2"));
-        assertEquals("{103:ABC}", nested.getTagValue("3"));
-        assertEquals("\r\n" + ":15A:\r\n" + ":20:R317703\r\n" + ":22A:NEWT\r\n" + "-", nested.getTagValue("4"));
-        assertEquals("{CHK:73AC90A7A3F1}{SYS:1309041018SMAIBE22AXXX0246001570}", nested.getTagValue("5"));
-
-        SwiftMessage mt = new SwiftMessage();
-        mt.addBlock(SwiftParser.parseBlock1(nested.getTagValue("1")));
-        mt.addBlock(SwiftParser.parseBlock2(nested.getTagValue("2")));
-        mt.addBlock(SwiftParser.parseBlock3(nested.getTagValue("3")));
-        mt.addBlock(SwiftParser.parseBlock4(nested.getTagValue("4")));
-        mt.addBlock(SwiftParser.parseBlock5(nested.getTagValue("5")));
-        assertNotNull(mt.getBlock1());
-        assertNotNull(mt.getBlock2());
-        assertEquals(1, mt.getBlock3().size());
-        assertEquals(3, mt.getBlock4().size());
-        assertEquals(2, mt.getBlock5().size());
     }
 }


### PR DESCRIPTION
The block 4 of these system messages carries nested blocks, which the tag list block parser was splitting at the first closing brace. As a result the nested block 3 and block 5 lost their closing brace, their sub-tags leaked as siblings of the block 4 (colliding with the MT021 field 108) and the MT056 field 270 was truncated, so the message could not be written back as valid FIN.

The tag value is now read balancing the curly braces, but only for the tag names where SWIFT defines nested blocks: the block identifiers 1 to 5 and the field
270. Every other tag keeps the historical reading, which matters for malformed content such as a service message error code left unclosed before the next field. Verified with no difference over the 8833 FIN samples of the integrator corpus.

Also, parseBlock3 and parseBlock5 now accept the block content without the block identifier, which is the form returned by the nested block tag values, so the nested message can be rebuilt out of them.