### PR TITLE
(CU-86bbru6bd) Bump GitHub Actions to Node 24 runtimes and fix maintenance branch matching

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -27,15 +27,15 @@ jobs:
         uses: actions/checkout@v7
 
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@v2
+        uses: github/codeql-action/init@v4
         with:
           languages: ${{ matrix.language }}
           queries: +security-and-quality
 
       - name: Autobuild
-        uses: github/codeql-action/autobuild@v2
+        uses: github/codeql-action/autobuild@v4
 
       - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@v2
+        uses: github/codeql-action/analyze@v4
         with:
           category: "/language:${{ matrix.language }}"

--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -40,6 +40,8 @@ jobs:
       # See: https://github.com/gradle/actions/blob/main/setup-gradle/README.md
       - name: Setup Gradle
         uses: gradle/actions/setup-gradle@v6
+        with:
+          cache-provider: basic  # MIT provider; the v6 default 'enhanced' is proprietary and paid for private repos
 
       - name: Build with Gradle Wrapper
         run: ./gradlew build
@@ -65,4 +67,5 @@ jobs:
       - name: Generate and submit dependency graph
         uses: gradle/actions/dependency-submission@v6
         with:
+          cache-provider: basic  # MIT provider; the v6 default 'enhanced' is proprietary and paid for private repos
           dependency-graph-exclude-projects: ':buildSrc'

--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -4,7 +4,7 @@ name: Java CI with Gradle
 
 on:
   push:
-    branches: [ "main", "java8-maintenance", "SRU2025" ]
+    branches: [ "main", "SRU2026", "SRU2025-java8-maintenance", "SRU2026-java8-maintenance" ]
 #  pull_request:
 #    branches: [ "main" ]
 
@@ -20,17 +20,18 @@ jobs:
       - uses: actions/checkout@v7
 
       # Set the JDK 11 for the latest code branch (Prowide Core v10)
+      # Suffix match so every SRU<year>-java8-maintenance branch is covered, not one hardcoded name.
       - name: Set up JDK 11
-        if: github.ref != 'refs/heads/java8-maintenance' && github.head_ref != 'java8-maintenance'
-        uses: actions/setup-java@v4
+        if: ${{ !endsWith(github.head_ref || github.ref_name, 'java8-maintenance') }}
+        uses: actions/setup-java@v6
         with:
           java-version: '11'
           distribution: 'temurin'
 
-      # Set the JDK 8 for the legacy code branch
+      # Set the JDK 8 for the legacy code branches
       - name: Set up JDK 8
-        if: github.ref == 'refs/heads/java8-maintenance' || github.head_ref == 'java8-maintenance'
-        uses: actions/setup-java@v4
+        if: ${{ endsWith(github.head_ref || github.ref_name, 'java8-maintenance') }}
+        uses: actions/setup-java@v6
         with:
           java-version: '8'
           distribution: 'temurin'
@@ -38,13 +39,13 @@ jobs:
       # Configure Gradle for optimal use in GitHub Actions, including caching of downloaded dependencies.
       # See: https://github.com/gradle/actions/blob/main/setup-gradle/README.md
       - name: Setup Gradle
-        uses: gradle/actions/setup-gradle@v4
+        uses: gradle/actions/setup-gradle@v6
 
       - name: Build with Gradle Wrapper
         run: ./gradlew build
 
   # This job generates and submits a dependency graph, enabling Dependabot Alerts for all project dependencies.
-  # We only do it for the SRU2024_v10 branch to avoid spamming the Dependabot alerts for the legacy Java 8 code.
+  # We only run it on the default branch to avoid spamming the Dependabot alerts for the maintenance branches.
   dependency-submission:
     if: github.ref == 'refs/heads/main' || github.head_ref == 'main'
     runs-on: ubuntu-latest
@@ -54,7 +55,7 @@ jobs:
     steps:
       - uses: actions/checkout@v7
       - name: Set up JDK 11
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@v6
         with:
           java-version: '11'
           distribution: 'temurin'
@@ -62,6 +63,6 @@ jobs:
       # Generates and submits a dependency graph, enabling Dependabot Alerts for all project dependencies.
       # See: https://github.com/gradle/actions/blob/main/dependency-submission/README.md
       - name: Generate and submit dependency graph
-        uses: gradle/actions/dependency-submission@v4
+        uses: gradle/actions/dependency-submission@v6
         with:
           dependency-graph-exclude-projects: ':buildSrc'


### PR DESCRIPTION
## Summary
- GitHub runners now force Node 20 actions onto Node 24 and warn on every run. `setup-java` v4 → **v6** and `gradle/actions` (`setup-gradle`, `dependency-submission`) v4 → **v6**; both declare `node24`. Every input in use (`java-version`, `distribution`, `dependency-graph-exclude-projects`) exists unchanged at the new majors — verified by reading `action.yml` at each target tag.
- `codeql-action` v2 → **v4**. v2 has been out of support for a long time, so these scans were running degraded.
- **Pre-existing defect, fixed here:** the push trigger listed `java8-maintenance` and `SRU2025`, neither of which exists. The live branches are `SRU2026`, `SRU2025-java8-maintenance` and `SRU2026-java8-maintenance`, so the build job has not run on any maintenance branch. The JDK 8/11 conditions keyed off the same dead name and now match the `java8-maintenance` suffix instead.
- Stale comment on the `dependency-submission` job corrected — it claimed `SRU2024_v10` while the condition is `main`.

**Cache provider — updated after review.** `gradle/actions@v6` defaults to `cache-provider: enhanced`, the proprietary `gradle-actions-caching` component: free forever on public repositories, but a Free Preview on private ones with usage-based pricing planned. Prowide will not take that on, so every `setup-gradle` and `dependency-submission` step now pins **`cache-provider: basic`** — the MIT implementation over `@actions/cache`, free for all repositories. The proprietary component is then never loaded and the Gradle Terms of Use no longer apply to our CI. The cost is restore keys: basic caching matches an exact key only, so a change to any build file means the next run starts from an empty cache.

No CHANGELOG entry: SCM/build configuration only.

## Test plan
- [x] All workflow files re-parse as valid YAML
- [x] Target tags confirmed `runs.using: node24` (`codeql-action@v4` likewise)
- [x] CodeQL analysis completes on this PR
- [ ] After merge: build job runs on a push to `SRU2026` and to a `*-java8-maintenance` branch, picking JDK 11 and JDK 8 respectively
- [ ] After merge: dependency graph still submitted on push to `main`

🤖 Generated with [Claude Code](https://claude.com/claude-code)