### PR TITLE
(CU-86bbn38ff) Report only the published artifact's classpaths to the dependency graph

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -62,10 +62,17 @@ jobs:
           java-version: '11'
           distribution: 'temurin'
 
-      # Generates and submits a dependency graph, enabling Dependabot Alerts for all project dependencies.
+      # Generates and submits a dependency graph, enabling Dependabot Alerts for the dependencies of the published artifact.
       # See: https://github.com/gradle/actions/blob/main/dependency-submission/README.md
+      #
+      # Only the main source set's compile and runtime classpaths are reported, which is exactly what ships in the
+      # published jar. Test-only dependencies (testImplementation) and buildscript/plugin dependencies (axion-release,
+      # spotless, quality plugin) are deliberately left out: they never reach library consumers, and reporting them
+      # produces Dependabot alerts (and downstream Vanta findings) for CVEs in build/test tooling that we cannot act on
+      # from this repo. Direct test dependencies are still kept current by Dependabot version updates (dependabot.yml).
       - name: Generate and submit dependency graph
         uses: gradle/actions/dependency-submission@v6
         with:
           cache-provider: basic  # MIT provider; the v6 default 'enhanced' is proprietary and paid for private repos
           dependency-graph-exclude-projects: ':buildSrc'
+          dependency-graph-include-configurations: '(compile|runtime)Classpath'

--- a/build.gradle
+++ b/build.gradle
@@ -69,7 +69,7 @@ dependencies {
     testImplementation 'jakarta.validation:jakarta.validation-api:3.1.1'
     testImplementation 'org.junit.jupiter:junit-jupiter:5.14.4'
     testImplementation 'org.junit.platform:junit-platform-launcher:1.14.4'
-    testImplementation 'org.assertj:assertj-core:3.27.6'
+    testImplementation 'org.assertj:assertj-core:3.27.7'
     testImplementation 'org.xmlunit:xmlunit-core:2.13.0'
     testImplementation 'org.xmlunit:xmlunit-matchers:2.13.0'
     testImplementation 'org.xmlunit:xmlunit-assertj:2.13.0'


### PR DESCRIPTION
Dependabot alerts in this repo come from the dependency-submission job, which
was uploading test and buildscript configurations too. Restrict the graph to
compileClasspath/runtimeClasspath so build/test-only CVEs (Jackson via
json-schema-validator, BouncyCastle via axion-release) stop raising alerts
and Vanta findings. Also bump assertj-core to 3.27.7 (alert #28).