### PR TITLE
(CU-86bbujdhn) Quote the hook script path in .claude/settings.json

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -4,8 +4,8 @@
       {
         "matcher": "Edit|Write|NotebookEdit",
         "hooks": [
-          { "type": "command", "command": "sh $CLAUDE_PROJECT_DIR/.claude/hooks/block-generated.sh" },
-          { "type": "command", "command": "sh $CLAUDE_PROJECT_DIR/.claude/hooks/no-author-tag.sh" }
+          { "type": "command", "command": "sh \"${CLAUDE_PROJECT_DIR}/.claude/hooks/block-generated.sh\"" },
+          { "type": "command", "command": "sh \"${CLAUDE_PROJECT_DIR}/.claude/hooks/no-author-tag.sh\"" }
         ]
       }
     ]


### PR DESCRIPTION
## Summary
- Quote the `${CLAUDE_PROJECT_DIR}` placeholder in the `.claude/settings.json` hook commands

These hooks already used shell form and work today, so this is hardening rather than a bug fix: `sh $CLAUDE_PROJECT_DIR/x.sh` breaks the day the checkout path contains a space. The hooks reference is explicit — *"In shell form, wrap each placeholder in double quotes."*

Companion to prowide/pw-swift-integrator#2019 and the other repos on this branch, which fixed the separate exec-form defect that broke hooks on native Windows. This change brings the last three repos to the same form, so every Prowide repo now writes hooks the same way.

No CHANGELOG entry: SCM/tooling configuration only.

## Test plan
- [ ] Trigger the hook and confirm it still fires
